### PR TITLE
Add app name to the metric name

### DIFF
--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -7,28 +7,29 @@ from logging import getLogger
 
 logger = getLogger("exporter")
 
+
 REQUEST_TIME = Histogram(
-            'starlette_request_duration_seconds',
-            'HTTP request duration, in seconds',
-            ('method', 'path', 'status_code'),
-        )
+    f"starlette_request_duration_seconds",
+    "HTTP request duration, in seconds",
+    ("method", "path", "status_code", "app_name"),
+)
+
 
 REQUEST_COUNT = Counter(
-            'starlette_requests_total',
-            'Total HTTP requests',
-            ('method', 'path', 'status_code'),
-        )
+    f"starlette_requests_total",
+    "Total HTTP requests",
+    ("method", "path", "status_code", "app_name"),
+)
+
 
 class PrometheusMiddleware(BaseHTTPMiddleware):
     """ Middleware that collects Prometheus metrics for each request.
         Use in conjuction with the Prometheus exporter endpoint handler.
     """
-
-
-
-    def __init__(self, app: ASGIApp, group_paths: bool = False):
+    def __init__(self, app: ASGIApp, group_paths: bool = False, app_name: str = "starlette"):
         super().__init__(app)
         self.group_paths = group_paths
+        self.app_name = app_name
 
     async def dispatch(self, request, call_next):
         method = request.method
@@ -57,7 +58,9 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
 
             end = time.time()
 
-            REQUEST_COUNT.labels(method, path, status_code).inc()
-            REQUEST_TIME.labels(method, path, status_code).observe(end - begin)
+            labels = [method, path, status_code, self.app_name]
+
+            REQUEST_COUNT.labels(*labels).inc()
+            REQUEST_TIME.labels(*labels).observe(end - begin)
 
         return response

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,14 +1,13 @@
 import pytest
 
-from logging import getLogger
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 from starlette.responses import JSONResponse
 from starlette.exceptions import HTTPException
 from starlette_exporter import PrometheusMiddleware, handle_metrics
 
-class TestMiddleware:
 
+class TestMiddleware:
     @pytest.fixture
     def app(self):
         """ create a test app with various endpoints for the test scenarios """
@@ -38,8 +37,7 @@ class TestMiddleware:
         """ test that requests appear in the counter """
         client.get('/200')
         metrics = client.get('/metrics').content.decode()
-
-        assert """starlette_requests_total{method="GET",path="/200",status_code="200"} 1.0""" in metrics
+        assert """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200"} 1.0""" in metrics
     
     def test_500(self, client):
         """ test that a handled exception (HTTPException) gets logged in the requests counter """
@@ -47,7 +45,7 @@ class TestMiddleware:
         client.get('/500')
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_requests_total{method="GET",path="/500",status_code="500"} 1.0""" in metrics
+        assert """starlette_requests_total{app_name="starlette",method="GET",path="/500",status_code="500"} 1.0""" in metrics
     
     def test_unhandled(self, client):
         """ test that an unhandled exception still gets logged in the requests counter """
@@ -57,7 +55,7 @@ class TestMiddleware:
             pass
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_requests_total{method="GET",path="/unhandled",status_code="500"} 1.0""" in metrics
+        assert """starlette_requests_total{app_name="starlette",method="GET",path="/unhandled",status_code="500"} 1.0""" in metrics
 
     def test_histogram(self, client):
         """ test that histogram buckets appear after making requests """
@@ -71,9 +69,9 @@ class TestMiddleware:
 
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_request_duration_seconds_bucket{le="0.005",method="GET",path="/200",status_code="200"}""" in metrics
-        assert """starlette_request_duration_seconds_bucket{le="0.005",method="GET",path="/500",status_code="500"}""" in metrics
-        assert """starlette_request_duration_seconds_bucket{le="0.005",method="GET",path="/unhandled",status_code="500"}""" in metrics
+        assert """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/200",status_code="200"}""" in metrics
+        assert """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/500",status_code="500"}""" in metrics
+        assert """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/unhandled",status_code="500"}""" in metrics
 
 
 class TestMiddlewareGroupedPaths:
@@ -109,7 +107,7 @@ class TestMiddlewareGroupedPaths:
         client.get('/200/111')
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_requests_total{method="GET",path="/200/{test_param}",status_code="200"} 1.0""" in metrics
+        assert """starlette_requests_total{app_name="starlette",method="GET",path="/200/{test_param}",status_code="200"} 1.0""" in metrics
     
     def test_500(self, client):
         """ test that a handled exception (HTTPException) gets logged in the requests counter """
@@ -117,7 +115,7 @@ class TestMiddlewareGroupedPaths:
         client.get('/500/1111')
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_requests_total{method="GET",path="/500/{test_param}",status_code="500"} 1.0""" in metrics
+        assert """starlette_requests_total{app_name="starlette",method="GET",path="/500/{test_param}",status_code="500"} 1.0""" in metrics
     
     def test_unhandled(self, client):
         """ test that an unhandled exception still gets logged in the requests counter """
@@ -127,7 +125,7 @@ class TestMiddlewareGroupedPaths:
             pass
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_requests_total{method="GET",path="/unhandled/{test_param}",status_code="500"} 1.0""" in metrics
+        assert """starlette_requests_total{app_name="starlette",method="GET",path="/unhandled/{test_param}",status_code="500"} 1.0""" in metrics
 
     def test_404(self, client):
         """ test that a 404 is handled properly, even though the path won't be matched """
@@ -137,7 +135,7 @@ class TestMiddlewareGroupedPaths:
             pass
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_requests_total{method="GET",path="/not_found/11111",status_code="404"} 1.0""" in metrics
+        assert """starlette_requests_total{app_name="starlette",method="GET",path="/not_found/11111",status_code="404"} 1.0""" in metrics
 
 
     def test_histogram(self, client):
@@ -152,6 +150,6 @@ class TestMiddlewareGroupedPaths:
 
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_request_duration_seconds_bucket{le="0.005",method="GET",path="/200/{test_param}",status_code="200"}""" in metrics
-        assert """starlette_request_duration_seconds_bucket{le="0.005",method="GET",path="/500/{test_param}",status_code="500"}""" in metrics
-        assert """starlette_request_duration_seconds_bucket{le="0.005",method="GET",path="/unhandled/{test_param}",status_code="500"}""" in metrics
+        assert """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/200/{test_param}",status_code="200"}""" in metrics
+        assert """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/500/{test_param}",status_code="500"}""" in metrics
+        assert """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/unhandled/{test_param}",status_code="500"}""" in metrics


### PR DESCRIPTION
I propose to add the `app_name` label for the metrics. Different fast api applications can be run in the same k8s cluster or on the same machine therefore it's good to have a easy way to distinguish applications.