### PR TITLE
ASGI3 and other misc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ pip install starlette_exporter
 
 `group_paths`: setting this to `True` will populate the path label using named parameters (if any) in the router path, e.g. `/api/v1/items/{item_id}`.  This will group requests together by endpoint (regardless of the value of `item_id`). This option may come with a performance hit for larger routers. Default is `False`, which will result in separate metrics for different URLs (e.g., `/api/v1/items/42`, `/api/v1/items/43`, etc.).
 
-Example: 
+`prefix`: Sets the prefix of the exported metric names (default: `starlette`).
+
+Example:
 ```python
-app.add_middleware(PrometheusMiddleware, app_name="hello_world", group_paths=True)
+app.add_middleware(PrometheusMiddleware, app_name="hello_world", group_paths=True, prefix='myapp')
 ```
 
 ## Developing

--- a/starlette_exporter/__init__.py
+++ b/starlette_exporter/__init__.py
@@ -1,8 +1,15 @@
 import os
-from prometheus_client import generate_latest, CONTENT_TYPE_LATEST, REGISTRY, multiprocess, CollectorRegistry
+from prometheus_client import (
+    generate_latest,
+    CONTENT_TYPE_LATEST,
+    REGISTRY,
+    multiprocess,
+    CollectorRegistry,
+)
 from starlette.responses import Response
 
 from .middleware import PrometheusMiddleware
+
 
 def handle_metrics(request):
     """ A handler to expose Prometheus metrics
@@ -17,6 +24,6 @@ def handle_metrics(request):
     if 'prometheus_multiproc_dir' in os.environ:
         registry = CollectorRegistry()
         multiprocess.MultiProcessCollector(registry)
-    
+
     headers = {'Content-Type': CONTENT_TYPE_LATEST}
     return Response(generate_latest(registry), status_code=200, headers=headers)

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -1,9 +1,11 @@
 """ Middleware for exporting Prometheus metrics using Starlette """
 import time
+from logging import getLogger
+
 from prometheus_client import Counter, Histogram
 from starlette.requests import Request
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
-from logging import getLogger
+
 
 logger = getLogger("exporter")
 
@@ -26,7 +28,10 @@ class PrometheusMiddleware:
     """ Middleware that collects Prometheus metrics for each request.
         Use in conjuction with the Prometheus exporter endpoint handler.
     """
-    def __init__(self, app: ASGIApp, group_paths: bool = False, app_name: str = "starlette"):
+
+    def __init__(
+        self, app: ASGIApp, group_paths: bool = False, app_name: str = "starlette"
+    ):
         self.app = app
         self.group_paths = group_paths
         self.app_name = app_name
@@ -59,16 +64,27 @@ class PrometheusMiddleware:
             # group_paths enables returning the original router path (with url param names)
             # for example, when using this option, requests to /api/product/1 and /api/product/3
             # will both be grouped under /api/product/{product_id}. See the README for more info.
-            if self.group_paths and request.scope.get('endpoint', None) and request.scope.get('router', None):
+            if (
+                self.group_paths
+                and request.scope.get('endpoint', None)
+                and request.scope.get('router', None)
+            ):
                 try:
                     # try to match the request scope's handler function against one of handlers in the app's router.
                     # if a match is found, return the path used to mount the handler (e.g. api/product/{product_id}).
                     path = [
-                        route for route in request.scope['router'].routes
-                        if (hasattr(route, 'endpoint') and route.endpoint == request.scope['endpoint'])
+                        route
+                        for route in request.scope['router'].routes
+                        if (
+                            hasattr(route, 'endpoint')
+                            and route.endpoint == request.scope['endpoint']
+                        )
                         # for endpoints handled by another app, like fastapi.staticfiles.StaticFiles,
                         # check if the request endpoint matches a mounted app.
-                        or (hasattr(route, 'app') and route.app == request.scope['endpoint'])
+                        or (
+                            hasattr(route, 'app')
+                            and route.app == request.scope['endpoint']
+                        )
                     ][0].path
                 except IndexError:
                     # no route matched.

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -1,8 +1,8 @@
 """ Middleware for exporting Prometheus metrics using Starlette """
 import time
 from prometheus_client import Counter, Histogram
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.types import ASGIApp
+from starlette.requests import Request
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from logging import getLogger
 
 logger = getLogger("exporter")
@@ -22,16 +22,22 @@ REQUEST_COUNT = Counter(
 )
 
 
-class PrometheusMiddleware(BaseHTTPMiddleware):
+class PrometheusMiddleware:
     """ Middleware that collects Prometheus metrics for each request.
         Use in conjuction with the Prometheus exporter endpoint handler.
     """
     def __init__(self, app: ASGIApp, group_paths: bool = False, app_name: str = "starlette"):
-        super().__init__(app)
+        self.app = app
         self.group_paths = group_paths
         self.app_name = app_name
 
-    async def dispatch(self, request, call_next):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] not in ["http"]:
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope)
+
         method = request.method
         path = request.url.path
         begin = time.time()
@@ -40,28 +46,29 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
         # or an unhandled exception occurs.
         status_code = 500
 
+        async def wrapped_send(message: Message) -> None:
+            if message['type'] == 'http.response.start':
+                nonlocal status_code
+                status_code = message['status']
+
+            await send(message)
+
         try:
-            response = await call_next(request)
-            status_code = response.status_code
-
-        except Exception as e:
-            raise e
-
+            await self.app(scope, receive, wrapped_send)
         finally:
             # group_paths enables returning the original router path (with url param names)
             # for example, when using this option, requests to /api/product/1 and /api/product/3
             # will both be grouped under /api/product/{product_id}. See the README for more info.
             if self.group_paths and request.scope.get('endpoint', None) and request.scope.get('router', None):
-
                 try:
                     # try to match the request scope's handler function against one of handlers in the app's router.
                     # if a match is found, return the path used to mount the handler (e.g. api/product/{product_id}).
                     path = [
                         route for route in request.scope['router'].routes
-                            if (hasattr(route, 'endpoint') and route.endpoint  == request.scope['endpoint'])
-                            # for endpoints handled by another app, like fastapi.staticfiles.StaticFiles,
-                            # check if the request endpoint matches a mounted app.
-                            or (hasattr(route, 'app') and route.app == request.scope['endpoint']) 
+                        if (hasattr(route, 'endpoint') and route.endpoint == request.scope['endpoint'])
+                        # for endpoints handled by another app, like fastapi.staticfiles.StaticFiles,
+                        # check if the request endpoint matches a mounted app.
+                        or (hasattr(route, 'app') and route.app == request.scope['endpoint'])
                     ][0].path
                 except IndexError:
                     # no route matched.
@@ -76,5 +83,3 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
 
             REQUEST_COUNT.labels(*labels).inc()
             REQUEST_TIME.labels(*labels).observe(end - begin)
-
-        return response

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -40,7 +40,7 @@ class PrometheusMiddleware:
 
         method = request.method
         path = request.url.path
-        begin = time.time()
+        begin = time.perf_counter()
 
         # Default status code used when the application does not return a valid response
         # or an unhandled exception occurs.
@@ -77,7 +77,7 @@ class PrometheusMiddleware:
                 except Exception as e:
                     logger.error(e)
 
-            end = time.time()
+            end = time.perf_counter()
 
             labels = [method, path, status_code, self.app_name]
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -22,11 +22,12 @@ class TestMiddleware:
         @app.route("/500")
         async def error(request):
             raise HTTPException(status_code=500, detail="this is a test error")
-            
+
         @app.route("/unhandled")
         async def unhandled(request):
             test_dict = {"yup": 123}
             return JSONResponse({"message": test_dict["value_error"]})
+
         return app
 
     @pytest.fixture
@@ -37,16 +38,22 @@ class TestMiddleware:
         """ test that requests appear in the counter """
         client.get('/200')
         metrics = client.get('/metrics').content.decode()
-        assert """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200"} 1.0""" in metrics
-    
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200"} 1.0"""
+            in metrics
+        )
+
     def test_500(self, client):
         """ test that a handled exception (HTTPException) gets logged in the requests counter """
 
         client.get('/500')
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_requests_total{app_name="starlette",method="GET",path="/500",status_code="500"} 1.0""" in metrics
-    
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="/500",status_code="500"} 1.0"""
+            in metrics
+        )
+
     def test_unhandled(self, client):
         """ test that an unhandled exception still gets logged in the requests counter """
         try:
@@ -55,7 +62,10 @@ class TestMiddleware:
             pass
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_requests_total{app_name="starlette",method="GET",path="/unhandled",status_code="500"} 1.0""" in metrics
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="/unhandled",status_code="500"} 1.0"""
+            in metrics
+        )
 
     def test_histogram(self, client):
         """ test that histogram buckets appear after making requests """
@@ -64,14 +74,23 @@ class TestMiddleware:
         client.get('/500')
         try:
             client.get('/unhandled')
-        except: 
+        except:
             pass
 
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/200",status_code="200"}""" in metrics
-        assert """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/500",status_code="500"}""" in metrics
-        assert """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/unhandled",status_code="500"}""" in metrics
+        assert (
+            """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/200",status_code="200"}"""
+            in metrics
+        )
+        assert (
+            """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/500",status_code="500"}"""
+            in metrics
+        )
+        assert (
+            """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/unhandled",status_code="500"}"""
+            in metrics
+        )
 
 
 class TestMiddlewareGroupedPaths:
@@ -91,11 +110,12 @@ class TestMiddlewareGroupedPaths:
         @app.route("/500/{test_param}")
         async def error(request):
             raise HTTPException(status_code=500, detail="this is a test error")
-            
+
         @app.route("/unhandled/{test_param}")
         async def unhandled(request):
             test_dict = {"yup": 123}
             return JSONResponse({"message": test_dict["value_error"]})
+
         return app
 
     @pytest.fixture
@@ -107,16 +127,22 @@ class TestMiddlewareGroupedPaths:
         client.get('/200/111')
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_requests_total{app_name="starlette",method="GET",path="/200/{test_param}",status_code="200"} 1.0""" in metrics
-    
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="/200/{test_param}",status_code="200"} 1.0"""
+            in metrics
+        )
+
     def test_500(self, client):
         """ test that a handled exception (HTTPException) gets logged in the requests counter """
 
         client.get('/500/1111')
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_requests_total{app_name="starlette",method="GET",path="/500/{test_param}",status_code="500"} 1.0""" in metrics
-    
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="/500/{test_param}",status_code="500"} 1.0"""
+            in metrics
+        )
+
     def test_unhandled(self, client):
         """ test that an unhandled exception still gets logged in the requests counter """
         try:
@@ -125,7 +151,10 @@ class TestMiddlewareGroupedPaths:
             pass
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_requests_total{app_name="starlette",method="GET",path="/unhandled/{test_param}",status_code="500"} 1.0""" in metrics
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="/unhandled/{test_param}",status_code="500"} 1.0"""
+            in metrics
+        )
 
     def test_404(self, client):
         """ test that a 404 is handled properly, even though the path won't be matched """
@@ -135,8 +164,10 @@ class TestMiddlewareGroupedPaths:
             pass
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_requests_total{app_name="starlette",method="GET",path="/not_found/11111",status_code="404"} 1.0""" in metrics
-
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="/not_found/11111",status_code="404"} 1.0"""
+            in metrics
+        )
 
     def test_histogram(self, client):
         """ test that histogram buckets appear after making requests """
@@ -145,11 +176,20 @@ class TestMiddlewareGroupedPaths:
         client.get('/500/12')
         try:
             client.get('/unhandled/111')
-        except: 
+        except:
             pass
 
         metrics = client.get('/metrics').content.decode()
 
-        assert """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/200/{test_param}",status_code="200"}""" in metrics
-        assert """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/500/{test_param}",status_code="500"}""" in metrics
-        assert """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/unhandled/{test_param}",status_code="500"}""" in metrics
+        assert (
+            """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/200/{test_param}",status_code="200"}"""
+            in metrics
+        )
+        assert (
+            """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/500/{test_param}",status_code="500"}"""
+            in metrics
+        )
+        assert (
+            """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/unhandled/{test_param}",status_code="500"}"""
+            in metrics
+        )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -105,6 +105,28 @@ class TestMiddleware:
             in metrics
         )
 
+    def test_app_name(self, testapp):
+        """ test that app_name label is populated correctly """
+        client = TestClient(testapp(app_name="testing"))
+
+        client.get('/200')
+        metrics = client.get('/metrics').content.decode()
+        assert (
+            """starlette_requests_total{app_name="testing",method="GET",path="/200",status_code="200"} 1.0"""
+            in metrics
+        )
+
+    def test_prefix(self, testapp):
+        """ test that app_name label is populated correctly """
+        client = TestClient(testapp(prefix="myapp"))
+
+        client.get('/200')
+        metrics = client.get('/metrics').content.decode()
+        assert (
+            """myapp_requests_total{app_name="starlette",method="GET",path="/200",status_code="200"} 1.0"""
+            in metrics
+        )
+
 
 class TestMiddlewareGroupedPaths:
     """ tests for group_paths option (using named parameters to group endpoint metrics with path params together) """


### PR DESCRIPTION
A small set of improvements — I can split them up into separate PRs if you need it.

Each commit is self-contained

1. Change middleware to be a generic ASGI3 middleware. Starlette is discouraging use of BaseHTTPMiddleware because it causes all sorts of problems with streaming requests & responses. eg: https://github.com/encode/starlette/issues/919#issuecomment-672908610 and others. Personally, I'm running into early EOFs during reading `request.stream()` when `PrometheusMiddleware` (or anything `BaseHTTPMiddleware`-derived) is active.

2. Use [`time.perf_counter()`](https://docs.python.org/3/library/time.html#time.perf_counter) instead of `time.time()`. It doesn't go backwards and it operates at a higher precision

5. Add prefix option for metric naming #3 