### PR TITLE
Update multiproc env flag to uppercase (lowercase variable has been deprecated)

### DIFF
--- a/starlette_exporter/__init__.py
+++ b/starlette_exporter/__init__.py
@@ -21,7 +21,10 @@ def handle_metrics(request):
         ```
     """
     registry = REGISTRY
-    if 'prometheus_multiproc_dir' in os.environ:
+    if (
+        'prometheus_multiproc_dir' in os.environ
+        or 'PROMETHEUS_MULTIPROC_DIR' in os.environ
+    ):
         registry = CollectorRegistry()
         multiprocess.MultiProcessCollector(registry)
 


### PR DESCRIPTION
Lowercase flag "prometheus_multiproc_dir" variable has been deprecated in favor of "PROMETHEUS_MULTIPROC_DIR"

Check [here](https://github.com/prometheus/client_python/blob/9118c02a9dfee530af9e83924a88be1ac4994bc0/prometheus_client/multiprocess.py#L30) for more information :)

Regards