### PR TITLE
Test against multiple Pythons

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,27 +9,43 @@ on:
       - master
 
 jobs:
-  build:
-
+  lint:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
     - name: Lint with flake8
       run: |
+        python -m pip install --upgrade pip
         pip install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+  test:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
     - name: Test with pytest
       run: |
         pip install pytest

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ For more information, see the [Prometheus Python client documentation](https://g
 
 ## Developing
 
+This package supports Python 3.6+.
+
 ```sh
 git clone https://github.com/stephenhillier/starlette_exporter
 cd starlette_exporter


### PR DESCRIPTION
I'm grateful this package exists so figured a small contribution might be nice!

This addresses #25 by:

- Running the test suite against Python 3.6–3.10.
- Running the linting in a separate step so as not to repeat it for each Python version (it should be agnostic).
- Adding a notice to the README about supported Python versions ("3.6+").