### PR TITLE
add hostname to labels #45

### DIFF
--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -72,6 +72,8 @@ class PrometheusMiddleware:
         if headers_labels is not None:
             self.headers_labels = headers_labels
             for i in headers_labels:
+                if "-" in i:
+                    i = i.replace("-", "_")
                 self.labels_.append(i)
             self.labels_ = tuple(self.labels_)
         else:
@@ -223,8 +225,8 @@ class PrometheusMiddleware:
             labels = [method, path, status_code, self.app_name]
             if self.headers_labels != None:
                 for i in self.headers_labels:
-                    if i in request.headers.keys():
-                        labels.append(request.headers[i])
+                    if i.lower() in request.headers.keys():
+                        labels.append(request.headers[i.lower()])
                     else:
                         labels.append("None")
             

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -223,7 +223,7 @@ class PrometheusMiddleware:
             labels = [method, path, status_code, self.app_name]
             if self.headers_labels != None:
                 for i in self.headers_labels:
-                    if request.headers[i]:
+                    if i in request.headers.keys:
                         labels.append(request.headers[i])
                     else:
                         labels.append("None")

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -66,14 +66,14 @@ class PrometheusMiddleware:
         self.optional_metrics_list = []
         if optional_metrics is not None:
             self.optional_metrics_list = optional_metrics
-        
+
+        self.labels_ = ["method", "path", "status_code", "app_name"]
         self.headers_labels = []
         if headers_labels is not None:
             self.headers_labels = headers_labels
-            labels_ = ["method", "path", "status_code", "app_name"].extend(headers_labels)
-            self.labels_ = tuple(labels_)
+            self.labels_ = tuple(self.labels_.extend(headers_labels))
         else:
-            self.labels_ = ("method", "path", "status_code", "app_name")
+            self.labels_ = tuple(self.labels_)
     # Starlette initialises middleware multiple times, so store metrics on the class
 
     @property

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -48,6 +48,7 @@ class PrometheusMiddleware:
         filter_unhandled_paths: bool = False,
         skip_paths: Optional[List[str]] = None,
         optional_metrics: Optional[List[str]] = None,
+        hn_ext: bool = False,
     ):
         self.app = app
         self.group_paths = group_paths
@@ -55,6 +56,7 @@ class PrometheusMiddleware:
         self.prefix = prefix
         self.filter_unhandled_paths = filter_unhandled_paths
         self.kwargs = {}
+        self.hn_ext = hn_ext
         if buckets is not None:
             self.kwargs['buckets'] = buckets
         self.skip_paths = []
@@ -150,7 +152,11 @@ class PrometheusMiddleware:
 
 
         method = request.method
-        path = request.url.path
+        
+        if self.hn_ext:
+            path = request.headers['host'] + request.url.path
+        else:
+            path = request.url.path
 
         if path in self.skip_paths:
             await self.app(scope, receive, send)

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -232,12 +232,12 @@ class PrometheusMiddleware:
             if end is None:
                 end = time.perf_counter()
 
-            self.request_count.labels(*labels).inc(str(extra_labels_header))
-            self.request_time.labels(*labels).observe(end - begin, str(extra_labels_header))
+            self.request_count.labels(*labels).inc(exemplar=extra_labels_header)
+            self.request_time.labels(*labels).observe(end - begin)
             if self.optional_metrics_list != None and 'response_body_bytes' in self.optional_metrics_list or 'all' in self.optional_metrics_list:
-                self.request_response_body_size_count.labels(*labels).inc(b_size, str(extra_labels_header))
+                self.request_response_body_size_count.labels(*labels).inc(b_size,)
             if self.optional_metrics_list != None and 'request_body_bytes' in self.optional_metrics_list or 'all' in self.optional_metrics_list:
-                self.client_receive_body_size_count.labels(*labels).inc(receive_size, str(extra_labels_header))
+                self.client_receive_body_size_count.labels(*labels).inc(receive_size)
 
     @staticmethod
     def _get_router_path(scope: Scope) -> Optional[str]:

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -71,8 +71,9 @@ class PrometheusMiddleware:
         if headers_labels is not None:
             self.headers_labels = headers_labels
             self.labels_ = ["method", "path", "status_code", "app_name"].extend(headers_labels)
+            self.labels_ = tuple(self.labels_)
         else:
-            self.labels_ = ["method", "path", "status_code", "app_name"]
+            self.labels_ = ("method", "path", "status_code", "app_name")
     # Starlette initialises middleware multiple times, so store metrics on the class
 
     @property

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -71,7 +71,9 @@ class PrometheusMiddleware:
         self.headers_labels = []
         if headers_labels is not None:
             self.headers_labels = headers_labels
-            self.labels_ = tuple(self.labels_.extend(self.headers_labels))
+            for i in headers_labels:
+                self.labels_.append(i)
+            self.labels_ = tuple(self.labels_)
         else:
             self.labels_ = tuple(self.labels_)
     # Starlette initialises middleware multiple times, so store metrics on the class

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -70,8 +70,8 @@ class PrometheusMiddleware:
         self.headers_labels = []
         if headers_labels is not None:
             self.headers_labels = headers_labels
-            self.labels_ = ["method", "path", "status_code", "app_name"].extend(headers_labels)
-            self.labels_ = tuple(self.labels_)
+            labels_ = ["method", "path", "status_code", "app_name"].extend(headers_labels)
+            self.labels_ = tuple(labels_)
         else:
             self.labels_ = ("method", "path", "status_code", "app_name")
     # Starlette initialises middleware multiple times, so store metrics on the class

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -232,12 +232,12 @@ class PrometheusMiddleware:
             if end is None:
                 end = time.perf_counter()
 
-            self.request_count.labels(*labels).inc(extra_labels)
-            self.request_time.labels(*labels).observe(end - begin,extra_labels)
+            self.request_count.labels(*labels).inc(extra_labels_header)
+            self.request_time.labels(*labels).observe(end - begin,extra_labels_header)
             if self.optional_metrics_list != None and 'response_body_bytes' in self.optional_metrics_list or 'all' in self.optional_metrics_list:
-                self.request_response_body_size_count.labels(*labels).inc(b_size, extra_labels)
+                self.request_response_body_size_count.labels(*labels).inc(b_size, extra_labels_header)
             if self.optional_metrics_list != None and 'request_body_bytes' in self.optional_metrics_list or 'all' in self.optional_metrics_list:
-                self.client_receive_body_size_count.labels(*labels).inc(receive_size, extra_labels)
+                self.client_receive_body_size_count.labels(*labels).inc(receive_size, extra_labels_header)
 
     @staticmethod
     def _get_router_path(scope: Scope) -> Optional[str]:

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -70,7 +70,7 @@ class PrometheusMiddleware:
         self.headers_labels = []
         if headers_labels is not None:
             self.headers_labels = headers_labels
-            self.labels_ = tuple(["method", "path", "status_code", "app_name"].extend(self.headers_labels))
+            self.labels_ = tuple(["method", "path", "status_code", "app_name"].extend(headers_labels))
         else:
             self.labels_ = ("method", "path", "status_code", "app_name")
     # Starlette initialises middleware multiple times, so store metrics on the class

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -216,11 +216,8 @@ class PrometheusMiddleware:
                     path = grouped_path
             
             labels = [method, path, status_code, self.app_name]
-            if not self.headers_labels:
-                pass
-            else:
-                for i in self.labels_:
-                    labels.append(request.headers[i])
+            for i in self.labels_:
+                labels.append(request.headers[i])
             
 
             # if we were not able to set end when the response body was written,

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -70,9 +70,9 @@ class PrometheusMiddleware:
         self.headers_labels = []
         if headers_labels is not None:
             self.headers_labels = headers_labels
-            self.labels_ = tuple(["method", "path", "status_code", "app_name"].extend(headers_labels))
+            self.labels_ = ["method", "path", "status_code", "app_name"].extend(headers_labels)
         else:
-            self.labels_ = ("method", "path", "status_code", "app_name")
+            self.labels_ = ["method", "path", "status_code", "app_name"]
     # Starlette initialises middleware multiple times, so store metrics on the class
 
     @property

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -66,6 +66,8 @@ class PrometheusMiddleware:
         self.optional_metrics_list = []
         if optional_metrics is not None:
             self.optional_metrics_list = optional_metrics
+        
+        self.headers_labels = []
         if headers_labels is not None:
             self.headers_labels = headers_labels
             self.labels_ = tuple(["method", "path", "status_code", "app_name"].extend(self.headers_labels))
@@ -216,7 +218,7 @@ class PrometheusMiddleware:
                     path = grouped_path
             
             labels = [method, path, status_code, self.app_name]
-            if self.headers_labels is not None:
+            if self.headers_labels != None:
                 for i in self.headers_labels:
                     if request.headers[i]:
                         labels.append(request.headers[i])

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -82,7 +82,7 @@ class PrometheusMiddleware:
             PrometheusMiddleware._metrics[metric_name] = Counter(
                 metric_name,
                 "Total HTTP requests",
-                self.labels_,
+                ("method", "path", "status_code", "app_name"),
             )
         return PrometheusMiddleware._metrics[metric_name]
 
@@ -97,7 +97,7 @@ class PrometheusMiddleware:
                 PrometheusMiddleware._metrics[metric_name] = Counter(
                     metric_name,
                     "Total HTTP response body bytes",
-                    self.labels_,
+                    ("method", "path", "status_code", "app_name"),
                 )
             return PrometheusMiddleware._metrics[metric_name]
         else:
@@ -114,7 +114,7 @@ class PrometheusMiddleware:
                 PrometheusMiddleware._metrics[metric_name] = Counter(
                     metric_name,
                     "Total HTTP request body bytes",
-                    self.labels_,
+                    ("method", "path", "status_code", "app_name"),
                 )
             return PrometheusMiddleware._metrics[metric_name]
         else:
@@ -127,7 +127,7 @@ class PrometheusMiddleware:
             PrometheusMiddleware._metrics[metric_name] = Histogram(
                 metric_name,
                 "HTTP request duration, in seconds",
-                self.labels_,
+                ("method", "path", "status_code", "app_name"),
                 **self.kwargs,
             )
         return PrometheusMiddleware._metrics[metric_name]

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -216,8 +216,9 @@ class PrometheusMiddleware:
                     path = grouped_path
             
             labels = [method, path, status_code, self.app_name]
-            for i in self.labels_:
-                labels.append(request.headers[i])
+            for i in self.headers_labels:
+                if request.headers[i]:
+                    labels.append(request.headers[i])
             
 
             # if we were not able to set end when the response body was written,

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -225,6 +225,8 @@ class PrometheusMiddleware:
                 for i in self.headers_labels:
                     if request.headers[i]:
                         labels.append(request.headers[i])
+                    else:
+                        labels.append("None")
             
 
             # if we were not able to set end when the response body was written,

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -223,7 +223,7 @@ class PrometheusMiddleware:
             labels = [method, path, status_code, self.app_name]
             if self.headers_labels != None:
                 for i in self.headers_labels:
-                    if i in request.headers.keys:
+                    if i in request.headers.keys():
                         labels.append(request.headers[i])
                     else:
                         labels.append("None")

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -216,9 +216,10 @@ class PrometheusMiddleware:
                     path = grouped_path
             
             labels = [method, path, status_code, self.app_name]
-            for i in self.headers_labels:
-                if request.headers[i]:
-                    labels.append(request.headers[i])
+            if self.headers_labels is not None:
+                for i in self.headers_labels:
+                    if request.headers[i]:
+                        labels.append(request.headers[i])
             
 
             # if we were not able to set end when the response body was written,

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -232,12 +232,12 @@ class PrometheusMiddleware:
             if end is None:
                 end = time.perf_counter()
 
-            self.request_count.labels(*labels).inc(extra_labels_header)
-            self.request_time.labels(*labels).observe(end - begin,extra_labels_header)
+            self.request_count.labels(*labels).inc(str(extra_labels_header))
+            self.request_time.labels(*labels).observe(end - begin, str(extra_labels_header))
             if self.optional_metrics_list != None and 'response_body_bytes' in self.optional_metrics_list or 'all' in self.optional_metrics_list:
-                self.request_response_body_size_count.labels(*labels).inc(b_size, extra_labels_header)
+                self.request_response_body_size_count.labels(*labels).inc(b_size, str(extra_labels_header))
             if self.optional_metrics_list != None and 'request_body_bytes' in self.optional_metrics_list or 'all' in self.optional_metrics_list:
-                self.client_receive_body_size_count.labels(*labels).inc(receive_size, extra_labels_header)
+                self.client_receive_body_size_count.labels(*labels).inc(receive_size, str(extra_labels_header))
 
     @staticmethod
     def _get_router_path(scope: Scope) -> Optional[str]:

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -71,7 +71,7 @@ class PrometheusMiddleware:
         self.headers_labels = []
         if headers_labels is not None:
             self.headers_labels = headers_labels
-            self.labels_ = tuple(self.labels_.extend(headers_labels))
+            self.labels_ = tuple(self.labels_.extend(self.headers_labels))
         else:
             self.labels_ = tuple(self.labels_)
     # Starlette initialises middleware multiple times, so store metrics on the class

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -515,6 +515,6 @@ class TestHeadersLabels:
             'user="myuseragent"' in s and 'path="/200"' in s and 'host="foo.bar"' in s)]
         rec_size = rec_size_metric[0].split('} ')[0]+"}"
         assert (
-            """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200", host="foo.bar", user="myuseragent"}"""
+            """starlette_requests_total{app_name="starlette",host="foo.bar",method="GET",path="/200",status_code="200",user="myuseragent"}"""
             in rec_size
         )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -513,8 +513,8 @@ class TestHeadersLabels:
         metrics = client.get('/metrics').content.decode()
         rec_size_metric = [s for s in metrics.split('\n') if (
             'user="myuseragent"' in s and 'path="/200"' in s and 'host="foo.bar"' in s)]
-        rec_size = rec_size_metric[0].split('} ')[0]
+        rec_size = rec_size_metric[0].split('} ')[0]+}
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200", host="foo.bar", user="myuseragent"}"""
-            in rec_size+"}"
+            in rec_size
         )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -513,7 +513,7 @@ class TestHeadersLabels:
         metrics = client.get('/metrics').content.decode()
         rec_size_metric = [s for s in metrics.split('\n') if (
             'user="myuseragent"' in s and 'path="/200"' in s and 'host="foo.bar"' in s)]
-        rec_size = rec_size_metric[0].split('} ')[0]+}
+        rec_size = rec_size_metric[0].split('} ')[0]+"}"
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200", host="foo.bar", user="myuseragent"}"""
             in rec_size

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -491,11 +491,12 @@ class TestOptionalHostExt:
         return TestClient(testapp(hn_ext=True))
         
     def test_hn_ext(self, client):
-        """ test that requests appear in the counter """
+        """ adding to client get header 
+        'host' :  'foo.bar' to simulate the a request header hostname"""
         client.get('/200',
-            headers = {'host' : 'testhost1'},)
+            headers = {'host' : 'foo.bar'},)
         metrics = client.get('/metrics').content.decode()
         assert (
-            """starlette_requests_total{app_name="starlette",method="GET",path="testhost/200",status_code="200"} 1.0"""
+            """starlette_requests_total{app_name="starlette",method="GET",path="foo.bar/200",status_code="200"} 1.0"""
             in metrics
         )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -511,7 +511,10 @@ class TestHeadersLabels:
         client.get('/200',
             headers = {'host' : 'foo.bar', 'user': "myuseragent"},)
         metrics = client.get('/metrics').content.decode()
+        rec_size_metric = [s for s in metrics.split('\n') if (
+            'user="myuseragent"' in s and 'path="/200"' in s and 'host="foo.bar"' in s)]
+        rec_size = rec_size_metric[0].split('} ')[0]
         assert (
-            """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200", host="foo.bar", user="myuseragent"} 1.0"""
-            in metrics
+            """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200", host="foo.bar", user="myuseragent"}"""
+            in rec_size+"}"
         )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,3 +1,4 @@
+from wsgiref import headers
 import pytest
 import time
 from prometheus_client import REGISTRY
@@ -492,7 +493,7 @@ class TestOptionalHostExt:
     def test_hn_ext(self, client):
         """ test that requests appear in the counter """
         client.get('/200',
-            header = {'host' : 'testhost'},)
+            headers = {'host' : 'testhost'},)
         metrics = client.get('/metrics').content.decode()
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="testhost/200",status_code="200"} 1.0"""

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -490,8 +490,12 @@ class TestOptionalHostExt:
         return TestClient(testapp(hn_ext=True))
         
     def test_hn_ext(self, client):
-        """ adding to client get header 
-        'host' :  'foo.bar' to simulate the a request header hostname"""
+        """
+        Simulate path extend reading from headers value host 
+        https://www.ietf.org/rfc/rfc2616.txt
+        The Host request-header field (section 14.23) MUST accompany all
+        HTTP/1.1 requests.
+        """
         client.get('/200',
             headers = {'host' : 'foo.bar'},)
         metrics = client.get('/metrics').content.decode()
@@ -506,8 +510,13 @@ class TestHeadersLabels:
         return TestClient(testapp(headers_labels=["host", "user"]))
         
     def test_ok_headers(self, client):
-        """ adding to client get header 
-        'host' :  'foo.bar' to simulate the a request header hostname"""
+        """
+        Simulating matching headers
+        headers = {
+            'host': 'foobar',
+            'user': 'myuseragent'
+        }
+        """
         client.get('/200',
             headers = {'host' : 'foo.bar', 'user': "myuseragent"},)
         metrics = client.get('/metrics').content.decode()
@@ -519,8 +528,12 @@ class TestHeadersLabels:
             in rec_size
         )
     def test_missing_headers(self, client):
-        """ adding to client get header 
-        'host' :  'foo.bar' to simulate the a request header hostname"""
+        """
+        Simulating missing 'user' in the header
+        headers = {
+            'host': 'foobar'
+        }
+        """
         client.get('/200',
             headers = {'host' : 'foo.bar'},)
         metrics = client.get('/metrics').content.decode()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,4 +1,3 @@
-from wsgiref import headers
 import pytest
 import time
 from prometheus_client import REGISTRY
@@ -498,5 +497,21 @@ class TestOptionalHostExt:
         metrics = client.get('/metrics').content.decode()
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="foo.bar/200",status_code="200"} 1.0"""
+            in metrics
+        )
+
+class TestHeadersLabels:
+    @pytest.fixture
+    def client(self, testapp):
+        return TestClient(testapp(headers_labels=["host", "user-agent"]))
+        
+    def test_hn_ext(self, client):
+        """ adding to client get header 
+        'host' :  'foo.bar' to simulate the a request header hostname"""
+        client.get('/200',
+            headers = {'host' : 'foo.bar', 'user-agent': "myuseragent"},)
+        metrics = client.get('/metrics').content.decode()
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200", host="foo.bar", user-agent="myuseragent"} 1.0"""
             in metrics
         )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -503,15 +503,15 @@ class TestOptionalHostExt:
 class TestHeadersLabels:
     @pytest.fixture
     def client(self, testapp):
-        return TestClient(testapp(headers_labels=["host", "user-agent"]))
+        return TestClient(testapp(headers_labels=["host", "user"]))
         
     def test_hn_ext(self, client):
         """ adding to client get header 
         'host' :  'foo.bar' to simulate the a request header hostname"""
         client.get('/200',
-            headers = {'host' : 'foo.bar', 'user-agent': "myuseragent"},)
+            headers = {'host' : 'foo.bar', 'user': "myuseragent"},)
         metrics = client.get('/metrics').content.decode()
         assert (
-            """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200", host="foo.bar", user-agent="myuseragent"} 1.0"""
+            """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200", host="foo.bar", user="myuseragent"} 1.0"""
             in metrics
         )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -525,7 +525,7 @@ class TestHeadersLabels:
             headers = {'host' : 'foo.bar'},)
         metrics = client.get('/metrics').content.decode()
         rec_size_metric = [s for s in metrics.split('\n') if (
-            'user="myuseragent"' in s and 'path="/200"' in s and 'host="foo.bar"' in s)]
+            'starlette_requests_total' in s and 'path="/200"' in s and 'host="foo.bar"' in s)]
         rec_size = rec_size_metric[0].split('} ')[0]+"}"
         assert (
             """starlette_requests_total{app_name="starlette",host="foo.bar",method="GET",path="/200",status_code="200",user="None"}"""

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -525,7 +525,7 @@ class TestHeadersLabels:
             headers = {'host' : 'foo.bar'},)
         metrics = client.get('/metrics').content.decode()
         rec_size_metric = [s for s in metrics.split('\n') if (
-            'starlette_requests_total' in s and 'path="/200"' in s and 'host="foo.bar"' in s)]
+            'user="None"' in s and 'path="/200"' in s and 'host="foo.bar"' in s)]
         rec_size = rec_size_metric[0].split('} ')[0]+"}"
         assert (
             """starlette_requests_total{app_name="starlette",host="foo.bar",method="GET",path="/200",status_code="200",user="None"}"""

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -484,4 +484,17 @@ class TestOptionalMetrics:
         rec_size = rec_size_metric[0].split('} ')[1]
         assert float(rec_size) > 0.1
     
-
+class TestOptionalHostExt:
+    @pytest.fixture
+    def client(self, testapp):
+        return TestClient(testapp(hn_ext=True))
+        
+    def test_hn_ext(self, client):
+        """ test that requests appear in the counter """
+        client.get('/200',
+            header = {'host' : 'testhost'},)
+        metrics = client.get('/metrics').content.decode()
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="testhost/200",status_code="200"} 1.0"""
+            in metrics
+        )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -493,7 +493,7 @@ class TestOptionalHostExt:
     def test_hn_ext(self, client):
         """ test that requests appear in the counter """
         client.get('/200',
-            headers = {'host' : 'testhost'},)
+            headers = {'host' : 'testhost1'},)
         metrics = client.get('/metrics').content.decode()
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="testhost/200",status_code="200"} 1.0"""


### PR DESCRIPTION
Base by request on https://github.com/stephenhillier/starlette_exporter/issues/45 added an bool feature to enable to add hostname/url to the path value.
Enable:

`app.add_middleware(starelette_exporter.Prometheus, hn_ext=True)`

Output:
`starlette_requests_total{app_name="starlette",method="GET",path="<HTTP hearder host>/200",status_code="200"} 1.0`

This header is always on as pre http1.1 headers.
https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
[14.23] Host
