### PR TITLE
Feature always use int status

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,20 @@ Use the HTTP handler `handle_metrics` at path `/metrics` to expose a metrics end
 
 ## Table of Contents
 
-1. [Usage](#usage)
-    1. [Starlette](#starlette)
-    1. [FastAPI](#fastapi)
-1. [Options](#options)
-1. [Custom metrics](#custom-metrics)
-1. [Multiprocess mode (gunicorn deployments)](#multiprocess-mode-gunicorn-deployments)
-1. [Developing](#developing)
-1. [License](#license)
+- [starlette\_exporter](#starlette_exporter)
+  - [Prometheus exporter for Starlette and FastAPI](#prometheus-exporter-for-starlette-and-fastapi)
+  - [Table of Contents](#table-of-contents)
+  - [Usage](#usage)
+    - [Starlette](#starlette)
+    - [FastAPI](#fastapi)
+  - [Options](#options)
+  - [Custom Metrics](#custom-metrics)
+      - [Example:](#example)
+  - [Multiprocess mode (gunicorn deployments)](#multiprocess-mode-gunicorn-deployments)
+  - [Developing](#developing)
+  - [License](#license)
+  - [Dependencies](#dependencies)
+  - [Credits](#credits)
 
 ## Usage
 
@@ -74,9 +80,11 @@ app.add_route("/metrics", handle_metrics)
 
 `skip_paths`: accepts an optional list of paths that will not collect metrics. The default value is `None`, which will cause the library to collect metrics on every requested path. This option is useful to avoid collecting metrics on health check, readiness or liveness probe endpoints.
 
+`always_use_int_status`: accepts a boolean. The default value is False. If set to True the libary will attempt to convert the `status_code` value to an integer. If the conversion fails it will log a warning and use the initial value. This is useful if you use [`http.HTTStatus`](https://docs.python.org/3/library/http.html#http.HTTPStatus) in your code but want your metrics to emit only a integer status code.
+
 Example:
 ```python
-app.add_middleware(PrometheusMiddleware, app_name="hello_world", group_paths=True, prefix='myapp', buckets=[0.1, 0.25, 0.5], skip_paths=['/health'])
+app.add_middleware(PrometheusMiddleware, app_name="hello_world", group_paths=True, prefix='myapp', buckets=[0.1, 0.25, 0.5], skip_paths=['/health'], always_use_int_status=False)
 ```
 
 ## Custom Metrics

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -48,7 +48,7 @@ class PrometheusMiddleware:
         filter_unhandled_paths: bool = False,
         skip_paths: Optional[List[str]] = None,
         optional_metrics: Optional[List[str]] = None,
-        always_use_int_status: Optional[bool] = None,
+        always_use_int_status: bool = False,
     ):
         self.app = app
         self.group_paths = group_paths

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -48,6 +48,7 @@ class PrometheusMiddleware:
         filter_unhandled_paths: bool = False,
         skip_paths: Optional[List[str]] = None,
         optional_metrics: Optional[List[str]] = None,
+        always_use_int_status: Optional[bool] = None,
     ):
         self.app = app
         self.group_paths = group_paths
@@ -63,6 +64,8 @@ class PrometheusMiddleware:
         self.optional_metrics_list = []
         if optional_metrics is not None:
             self.optional_metrics_list = optional_metrics
+        self.always_use_int_status = always_use_int_status
+  
 
     # Starlette initialises middleware multiple times, so store metrics on the class
     @property
@@ -172,6 +175,15 @@ class PrometheusMiddleware:
             if message['type'] == 'http.response.start':
                 nonlocal status_code
                 status_code = message['status']
+
+                if self.always_use_int_status:
+                    try:
+                        status_code = int(message["status"])
+                    except ValueError as e:
+                        logger.warning(
+                            f"always_use_int_status flag selected but failed to convert status_code to int for value: {status_code}"
+                        )
+
                 if self.optional_metrics_list != None and 'response_body_bytes' in self.optional_metrics_list or 'all' in self.optional_metrics_list:
                     nonlocal b_size
                     for message_content_length in message['headers']:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,20 +1,24 @@
-import pytest
 import time
+from http import HTTPStatus
+
+import aiofiles
+import pytest
 from prometheus_client import REGISTRY
 from starlette.applications import Starlette
-from starlette.testclient import TestClient
-from starlette.responses import JSONResponse, PlainTextResponse
-from starlette.routing import Mount, Route, Router
-from starlette.exceptions import HTTPException
 from starlette.background import BackgroundTask
+from starlette.exceptions import HTTPException
+from starlette.responses import JSONResponse, PlainTextResponse, Response
+from starlette.routing import Mount, Route, Router
 from starlette.staticfiles import StaticFiles
-import aiofiles
+from starlette.testclient import TestClient
+
 import starlette_exporter
 from starlette_exporter import PrometheusMiddleware, handle_metrics
 
+
 @pytest.fixture
 def testapp():
-    """ create a test app with various endpoints for the test scenarios """
+    """create a test app with various endpoints for the test scenarios"""
 
     # unregister all the collectors before we start
     collectors = list(REGISTRY._collector_to_names.keys())
@@ -25,13 +29,37 @@ def testapp():
 
     def _testapp(**middleware_options):
         app = Starlette()
-        app.add_middleware(starlette_exporter.PrometheusMiddleware, **middleware_options)
+        app.add_middleware(
+            starlette_exporter.PrometheusMiddleware, **middleware_options
+        )
         app.add_route("/metrics", handle_metrics)
 
         @app.route("/200")
         @app.route("/200/{test_param}", methods=["GET", "OPTIONS"])
         def normal_response(request):
             return JSONResponse({"message": "Hello World"})
+
+        @app.route("/200_or_httpstatus/{test_param}", methods=["GET", "OPTIONS"])
+        def httpstatus_respnse(request):
+            """
+            Returns a JSON Response using status_code = HTTPStatus.OK if the param is set to OK
+            otherewise it returns a JSON response with status_code = 200
+            """
+            if request.path_params["test_param"] == "OK":
+                return Response(status_code=HTTPStatus.OK)
+            else:
+                return Response(status_code=200)
+
+        @app.route("/200_with_httpstatus/{test_param}", methods=["GET", "OPTIONS"])
+        def httpstatus_respnse(request):
+            """
+            Returns a JSON Response using status_code = HTTPStatus.OK if the param is set to OK
+            otherewise it returns a JSON response with status_code = 200
+            """
+            if request.path_params["test_param"] == "OK":
+                return Response(status_code=HTTPStatus.OK)
+            else:
+                return Response(status_code=200)
 
         @app.route("/500")
         @app.route("/500/{test_param}")
@@ -48,16 +76,17 @@ def testapp():
         async def background(request):
             def backgroundtask():
                 time.sleep(0.1)
+
             task = BackgroundTask(backgroundtask)
             return JSONResponse({"message": "task started"}, background=task)
 
         @app.route("/health")
         def healthcheck(request):
             return JSONResponse({"message": "Healthcheck route"})
-        
-        @app.route("/post_204", methods=['POST'])
+
+        @app.route("/post_204", methods=["POST"])
         def post_200(requets):
-            return  JSONResponse({"message": "post_200"})
+            return JSONResponse({"message": "post_200"})
 
         # testing routes added using Mount
         async def test_mounted_function(request):
@@ -66,14 +95,18 @@ def testapp():
         async def test_mounted_function_param(request):
             return JSONResponse({"message": request.path_params.get("item")})
 
-        mounted_routes = Mount("/", routes=[
-            Route("/test/{item}", test_mounted_function_param, methods=["GET"]),
-            Route("/test", test_mounted_function)
-        ])
+        mounted_routes = Mount(
+            "/",
+            routes=[
+                Route("/test/{item}", test_mounted_function_param, methods=["GET"]),
+                Route("/test", test_mounted_function),
+            ],
+        )
 
         app.mount("/mounted", mounted_routes)
-        app.mount('/static', app=StaticFiles(directory='tests/static'), name="static")
+        app.mount("/static", app=StaticFiles(directory="tests/static"), name="static")
         return app
+
     return _testapp
 
 
@@ -83,19 +116,19 @@ class TestMiddleware:
         return TestClient(testapp())
 
     def test_200(self, client):
-        """ test that requests appear in the counter """
-        client.get('/200')
-        metrics = client.get('/metrics').content.decode()
+        """test that requests appear in the counter"""
+        client.get("/200")
+        metrics = client.get("/metrics").content.decode()
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200"} 1.0"""
             in metrics
         )
 
     def test_500(self, client):
-        """ test that a handled exception (HTTPException) gets logged in the requests counter """
+        """test that a handled exception (HTTPException) gets logged in the requests counter"""
 
-        client.get('/500')
-        metrics = client.get('/metrics').content.decode()
+        client.get("/500")
+        metrics = client.get("/metrics").content.decode()
 
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="/500",status_code="500"} 1.0"""
@@ -103,12 +136,12 @@ class TestMiddleware:
         )
 
     def test_unhandled(self, client):
-        """ test that an unhandled exception still gets logged in the requests counter """
+        """test that an unhandled exception still gets logged in the requests counter"""
         try:
-            client.get('/unhandled')
+            client.get("/unhandled")
         except:
             pass
-        metrics = client.get('/metrics').content.decode()
+        metrics = client.get("/metrics").content.decode()
 
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="/unhandled",status_code="500"} 1.0"""
@@ -116,16 +149,16 @@ class TestMiddleware:
         )
 
     def test_histogram(self, client):
-        """ test that histogram buckets appear after making requests """
+        """test that histogram buckets appear after making requests"""
 
-        client.get('/200')
-        client.get('/500')
+        client.get("/200")
+        client.get("/500")
         try:
-            client.get('/unhandled')
+            client.get("/unhandled")
         except:
             pass
 
-        metrics = client.get('/metrics').content.decode()
+        metrics = client.get("/metrics").content.decode()
 
         assert (
             """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/200",status_code="200"}"""
@@ -141,18 +174,18 @@ class TestMiddleware:
         )
 
     def test_histogram_custom_buckets(self, testapp):
-        """ test that custom histogram buckets appear after making requests """
+        """test that custom histogram buckets appear after making requests"""
 
         buckets = (10, 20, 30, 40, 50)
         client = TestClient(testapp(buckets=buckets))
-        client.get('/200')
-        client.get('/500')
+        client.get("/200")
+        client.get("/500")
         try:
-            client.get('/unhandled')
+            client.get("/unhandled")
         except:
             pass
 
-        metrics = client.get('/metrics').content.decode()
+        metrics = client.get("/metrics").content.decode()
 
         assert (
             """starlette_request_duration_seconds_bucket{app_name="starlette",le="50.0",method="GET",path="/200",status_code="200"}"""
@@ -168,118 +201,100 @@ class TestMiddleware:
         )
 
     def test_app_name(self, testapp):
-        """ test that app_name label is populated correctly """
+        """test that app_name label is populated correctly"""
         client = TestClient(testapp(app_name="testing"))
 
-        client.get('/200')
-        metrics = client.get('/metrics').content.decode()
+        client.get("/200")
+        metrics = client.get("/metrics").content.decode()
         assert (
             """starlette_requests_total{app_name="testing",method="GET",path="/200",status_code="200"} 1.0"""
             in metrics
         )
 
     def test_filter_unhandled_paths(self, testapp):
-        """ test that app_name label is populated correctly """
+        """test that app_name label is populated correctly"""
         client = TestClient(testapp(filter_unhandled_paths=True))
 
-        client.get('/this_path_does_not_exist')
-        metrics = client.get('/metrics').content.decode()
-        assert 'this_path_does_not_exist' not in metrics
+        client.get("/this_path_does_not_exist")
+        metrics = client.get("/metrics").content.decode()
+        assert "this_path_does_not_exist" not in metrics
 
     def test_mounted_path(self, testapp):
-        """ test that mounted paths appear even when filter_unhandled_paths is True """
+        """test that mounted paths appear even when filter_unhandled_paths is True"""
         client = TestClient(testapp(filter_unhandled_paths=True))
-        client.get('/mounted/test')
-        metrics = client.get('/metrics').content.decode()
+        client.get("/mounted/test")
+        metrics = client.get("/metrics").content.decode()
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="/mounted/test",status_code="200"} 1.0"""
             in metrics
         )
 
     def test_mounted_path_with_param(self, testapp):
-        """ test that mounted paths appear even when filter_unhandled_paths is True
-            this test uses a path param that needs to be found within the mounted route.
+        """test that mounted paths appear even when filter_unhandled_paths is True
+        this test uses a path param that needs to be found within the mounted route.
         """
         client = TestClient(testapp(filter_unhandled_paths=True, group_paths=True))
-        client.get('/mounted/test/123')
-        metrics = client.get('/metrics').content.decode()
+        client.get("/mounted/test/123")
+        metrics = client.get("/metrics").content.decode()
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="/mounted/test/{item}",status_code="200"} 1.0"""
             in metrics
         )
 
     def test_mounted_path_unhandled(self, testapp):
-        """ test an unhandled path that will be partially matched at the mounted base path
-        """
+        """test an unhandled path that will be partially matched at the mounted base path"""
         client = TestClient(testapp(filter_unhandled_paths=True))
-        client.get('/mounted/unhandled/123')
-        metrics = client.get('/metrics').content.decode()
-        assert (
-            """path="/mounted/unhandled"""
-            not in metrics
-        )
+        client.get("/mounted/unhandled/123")
+        metrics = client.get("/metrics").content.decode()
+        assert """path="/mounted/unhandled""" not in metrics
 
-        assert (
-            """path="/mounted"""
-            not in metrics
-        )
+        assert """path="/mounted""" not in metrics
 
     def test_mounted_path_unhandled(self, testapp):
-        """ test an unhandled path that will be partially matched at the mounted base path
-        """
+        """test an unhandled path that will be partially matched at the mounted base path"""
         client = TestClient(testapp(filter_unhandled_paths=True, group_paths=True))
-        client.get('/mounted/unhandled/123')
-        metrics = client.get('/metrics').content.decode()
-        assert (
-            """path="/mounted/unhandled"""
-            not in metrics
-        )
+        client.get("/mounted/unhandled/123")
+        metrics = client.get("/metrics").content.decode()
+        assert """path="/mounted/unhandled""" not in metrics
 
-        assert (
-            """path="/mounted"""
-            not in metrics
-        )
+        assert """path="/mounted""" not in metrics
 
     def test_staticfiles_path(self, testapp):
-        """ test a static file path
-        """
+        """test a static file path"""
         client = TestClient(testapp(filter_unhandled_paths=True))
-        client.get('/static/test.txt')
-        metrics = client.get('/metrics').content.decode()
-        assert (
-            """path="/static/test.txt"""
-            in metrics
-        )
+        client.get("/static/test.txt")
+        metrics = client.get("/metrics").content.decode()
+        assert """path="/static/test.txt""" in metrics
 
     def test_prefix(self, testapp):
-        """ test that metric prefixes work """
+        """test that metric prefixes work"""
         client = TestClient(testapp(prefix="myapp"))
 
-        client.get('/200')
-        metrics = client.get('/metrics').content.decode()
+        client.get("/200")
+        metrics = client.get("/metrics").content.decode()
         assert (
             """myapp_requests_total{app_name="starlette",method="GET",path="/200",status_code="200"} 1.0"""
             in metrics
         )
 
     def test_multi_init(self, testapp):
-        """ test that the middleware is happy being initialised multiple times """
+        """test that the middleware is happy being initialised multiple times"""
         # newer starlette versions do this
         # prometheus doesn't like the same metric being registered twice.
         PrometheusMiddleware(None)
         PrometheusMiddleware(None)
 
     def test_multi_prefix(self, testapp):
-        """ test that two collecting apps don't clash """
+        """test that two collecting apps don't clash"""
         client1 = TestClient(testapp(prefix="app1"))
         client2 = TestClient(testapp(prefix="app2"))
 
-        client1.get('/200')
-        client2.get('/200')
+        client1.get("/200")
+        client2.get("/200")
 
         # both will return the same metrics though
-        metrics1 = client1.get('/metrics').content.decode()
-        metrics2 = client2.get('/metrics').content.decode()
+        metrics1 = client1.get("/metrics").content.decode()
+        metrics2 = client2.get("/metrics").content.decode()
 
         assert (
             """app1_requests_total{app_name="starlette",method="GET",path="/200",status_code="200"} 1.0"""
@@ -299,13 +314,13 @@ class TestMiddleware:
         )
 
     def test_requests_in_progress(self, client):
-        """ test that the requests_in_progress metric (a gauge) is incremented after one request.
-            This test is fairly trivial and doesn't cover decrementing at the end of the request.
-            TODO: create a second asyncronous request and check that the counter is incremented
-            multiple times (and decremented back to zero when all requests done).
+        """test that the requests_in_progress metric (a gauge) is incremented after one request.
+        This test is fairly trivial and doesn't cover decrementing at the end of the request.
+        TODO: create a second asyncronous request and check that the counter is incremented
+        multiple times (and decremented back to zero when all requests done).
         """
 
-        metrics = client.get('/metrics').content.decode()
+        metrics = client.get("/metrics").content.decode()
         assert (
             """starlette_requests_in_progress{app_name="starlette",method="GET"} 1.0"""
             in metrics
@@ -315,34 +330,31 @@ class TestMiddleware:
         # was decremented at the end of the first request.  This test could be improved, but
         # at the very least, it checks that the gauge wasn't incremented multiple times without
         # also being decremented.
-        metrics = client.get('/metrics').content.decode()
+        metrics = client.get("/metrics").content.decode()
         assert (
             """starlette_requests_in_progress{app_name="starlette",method="GET"} 1.0"""
             in metrics
         )
 
     def test_skip_paths(self, testapp):
-        """ test that requests doesn't appear in the counter """
-        client = TestClient(testapp(skip_paths=['/health']))
-        client.get('/health')
-        metrics = client.get('/metrics').content.decode()
-        assert (
-            """path="/health"""
-            not in metrics
-        )
+        """test that requests doesn't appear in the counter"""
+        client = TestClient(testapp(skip_paths=["/health"]))
+        client.get("/health")
+        metrics = client.get("/metrics").content.decode()
+        assert """path="/health""" not in metrics
 
 
 class TestMiddlewareGroupedPaths:
-    """ tests for group_paths option (using named parameters to group endpoint metrics with path params together) """
+    """tests for group_paths option (using named parameters to group endpoint metrics with path params together)"""
 
     @pytest.fixture
     def client(self, testapp):
         return TestClient(testapp(group_paths=True))
 
     def test_200(self, client):
-        """ test that metrics are grouped by endpoint """
-        client.get('/200/111')
-        metrics = client.get('/metrics').content.decode()
+        """test that metrics are grouped by endpoint"""
+        client.get("/200/111")
+        metrics = client.get("/metrics").content.decode()
 
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="/200/{test_param}",status_code="200"} 1.0"""
@@ -350,24 +362,22 @@ class TestMiddlewareGroupedPaths:
         )
 
     def test_200_options(self, client):
-        """ test that metrics are grouped by endpoint """
-        client.options('/200/111')
-        metrics = client.get('/metrics').content.decode()
+        """test that metrics are grouped by endpoint"""
+        client.options("/200/111")
+        metrics = client.get("/metrics").content.decode()
 
         assert (
             """starlette_requests_total{app_name="starlette",method="OPTIONS",path="/200/{test_param}",status_code="200"} 1.0"""
             in metrics
         )
 
-        assert (
-            """method="OPTIONS",path="/200/111""" not in metrics
-        )
+        assert """method="OPTIONS",path="/200/111""" not in metrics
 
     def test_500(self, client):
-        """ test that a handled exception (HTTPException) gets logged in the requests counter """
+        """test that a handled exception (HTTPException) gets logged in the requests counter"""
 
-        client.get('/500/1111')
-        metrics = client.get('/metrics').content.decode()
+        client.get("/500/1111")
+        metrics = client.get("/metrics").content.decode()
 
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="/500/{test_param}",status_code="500"} 1.0"""
@@ -375,12 +385,12 @@ class TestMiddlewareGroupedPaths:
         )
 
     def test_unhandled(self, client):
-        """ test that an unhandled exception still gets logged in the requests counter """
+        """test that an unhandled exception still gets logged in the requests counter"""
         try:
-            client.get('/unhandled/11111')
+            client.get("/unhandled/11111")
         except:
             pass
-        metrics = client.get('/metrics').content.decode()
+        metrics = client.get("/metrics").content.decode()
 
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="/unhandled/{test_param}",status_code="500"} 1.0"""
@@ -388,22 +398,19 @@ class TestMiddlewareGroupedPaths:
         )
 
     def test_staticfiles_path(self, testapp):
-        """ test a static file path, with group_paths=True
-        """
+        """test a static file path, with group_paths=True"""
         client = TestClient(testapp(filter_unhandled_paths=True, group_paths=True))
-        client.get('/static/test.txt')
-        metrics = client.get('/metrics').content.decode()
-        assert (
-            'path="/static"' in metrics
-        )
+        client.get("/static/test.txt")
+        metrics = client.get("/metrics").content.decode()
+        assert 'path="/static"' in metrics
 
     def test_404(self, client):
-        """ test that a 404 is handled properly, even though the path won't be matched """
+        """test that a 404 is handled properly, even though the path won't be matched"""
         try:
-            client.get('/not_found/11111')
+            client.get("/not_found/11111")
         except:
             pass
-        metrics = client.get('/metrics').content.decode()
+        metrics = client.get("/metrics").content.decode()
 
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="/not_found/11111",status_code="404"} 1.0"""
@@ -411,16 +418,16 @@ class TestMiddlewareGroupedPaths:
         )
 
     def test_histogram(self, client):
-        """ test that histogram buckets appear after making requests """
+        """test that histogram buckets appear after making requests"""
 
-        client.get('/200/1')
-        client.get('/500/12')
+        client.get("/200/1")
+        client.get("/500/12")
         try:
-            client.get('/unhandled/111')
+            client.get("/unhandled/111")
         except:
             pass
 
-        metrics = client.get('/metrics').content.decode()
+        metrics = client.get("/metrics").content.decode()
 
         assert (
             """starlette_request_duration_seconds_bucket{app_name="starlette",le="0.005",method="GET",path="/200/{test_param}",status_code="200"}"""
@@ -437,7 +444,7 @@ class TestMiddlewareGroupedPaths:
 
 
 class TestBackgroundTasks:
-    """ tests for ensuring the middleware handles requests involving background tasks """
+    """tests for ensuring the middleware handles requests involving background tasks"""
 
     @pytest.fixture
     def client(self, testapp):
@@ -446,10 +453,16 @@ class TestBackgroundTasks:
     def test_background_task_endpoint(self, client):
         client.get("/background")
 
-        metrics = client.get('/metrics').content.decode()
-        background_metric = [s for s in metrics.split('\n') if (
-            'starlette_request_duration_seconds_sum' in s and 'path="/background"' in s)]
-        duration = background_metric[0].split('} ')[1]
+        metrics = client.get("/metrics").content.decode()
+        background_metric = [
+            s
+            for s in metrics.split("\n")
+            if (
+                "starlette_request_duration_seconds_sum" in s
+                and 'path="/background"' in s
+            )
+        ]
+        duration = background_metric[0].split("} ")[1]
 
         # the test function contains a 0.1 second background task. Ensure the metric records the response
         # as smaller than 0.1 second.
@@ -457,31 +470,73 @@ class TestBackgroundTasks:
 
 
 class TestOptionalMetrics:
-    """ tests for optional additional metrics 
-        thanks to Stephen
+    """tests for optional additional metrics
+    thanks to Stephen
     """
+
     @pytest.fixture
     def client(self, testapp):
         return TestClient(testapp(optional_metrics=["all"]))
 
     def test_response_body_size(self, client):
-        client.get('/200')
+        client.get("/200")
 
-        metrics = client.get('/metrics').content.decode()
-        response_size_metric = [s for s in metrics.split('\n') if (
-            'starlette_response_body_bytes_total' in s and 'path="/200"' in s)]
-        response_size = response_size_metric[0].split('} ')[1]
+        metrics = client.get("/metrics").content.decode()
+        response_size_metric = [
+            s
+            for s in metrics.split("\n")
+            if ("starlette_response_body_bytes_total" in s and 'path="/200"' in s)
+        ]
+        response_size = response_size_metric[0].split("} ")[1]
         assert float(response_size) > 0.1
-    
+
     def test_receive_body_size(self, client):
-        client.post('/post_204',
-                    json={"test_post": ["d", "a"]}
-                    )
+        client.post("/post_204", json={"test_post": ["d", "a"]})
 
-        metrics = client.get('/metrics').content.decode()
-        rec_size_metric = [s for s in metrics.split('\n') if (
-            'starlette_request_body_bytes_total' in s and 'path="/post_204"' in s)]
-        rec_size = rec_size_metric[0].split('} ')[1]
+        metrics = client.get("/metrics").content.decode()
+        rec_size_metric = [
+            s
+            for s in metrics.split("\n")
+            if ("starlette_request_body_bytes_total" in s and 'path="/post_204"' in s)
+        ]
+        rec_size = rec_size_metric[0].split("} ")[1]
         assert float(rec_size) > 0.1
-    
 
+
+class TestAlwaysUseIntStatus:
+    """Tests for always_use_int_status flag
+    """
+
+    def test_200_with_always_use_int_status_set(self, testapp):
+        """test that even though the endpoint resturns a response with HTTP status it is converted to 200"""
+        client = TestClient(testapp(always_use_int_status=True))
+        client.get("/200_or_httpstatus/OK")
+        metrics = client.get("/metrics").content.decode()
+
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="/200_or_httpstatus/OK",status_code="200"} 1.0"""
+            in metrics
+        ), metrics
+
+    def test_200_HTTPStatusOK(self, testapp):
+        """Test that status_code metric is HTTPStatus.OK if status_code=HTTPStatus.OK in the response
+        and always_use_int_status is not set"""
+        client = TestClient(testapp())
+        client.get("/200_or_httpstatus/OK")
+        metrics = client.get("/metrics").content.decode()
+
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="/200_or_httpstatus/OK",status_code="HTTPStatus.OK"} 1.0"""
+            in metrics
+        ), metrics
+
+    def test_200_always_use_int_status_set(self, testapp):
+        """Test that status_code metric is 200 if status_code=200 in the response and always_use_int_status is set"""
+        client = TestClient(testapp(always_use_int_status=True))
+        client.get("/200")
+        metrics = client.get("/metrics").content.decode()
+
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200"} 1.0"""
+            in metrics
+        ), metrics


### PR DESCRIPTION
This pull request implements the `always_use_int_status` flag.

This flag attempts to convert the `status_code` value in a response to an integer.

This ensures consistent metrics when returning values with http.HTTPStatus code or an integer in the `status_code`.

Current behaviour will have produce duplicate metrics if somewhere else in the code uses can integer value.
