### PR TITLE
User-supplied labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ value or, optionally, a callback function.
 
 If a callback function is used, it will receive the Request instance as its argument.
 
-#### Examples:
-
 ```python
 app.add_middleware(
   PrometheusMiddleware,
@@ -127,21 +125,26 @@ app.add_middleware(
     }
 ```
 
-Alternatively, for header values, a convenience function is provided:
+This functionality is experimental.  Exceptions may be raised if the label name, value or callback function is malformed. 
+Ensure that label names follow [Prometheus naming conventions](https://prometheus.io/docs/practices/naming/).
+
+### Label helpers
+
+`from_header(key: string, allowed_values: Optional[Iterable])`:  a convenience function for using a header value as a label.
+`allowed_values` allows you to supply a list of allowed values. If supplied, header values not in the list will result in
+an empty string being returned.  This allows you to constrain the label values, reducing the risk of excessive cardinality.
+
 ```python
 from starlette_exporter import PrometheusMiddleware, from_header
 
 app.add_middleware(
   PrometheusMiddleware,
   labels={
-     "host": from_header("host")
+      "host": from_header("X-User", allowed_values=("frank", "estelle"))
     }
 ```
 
-For retrieving other types of values from the Request instance, use the lambda form.
 
-This functionality is experimental.  Exceptions may be raised if the label name, value or callback function is malformed. 
-Ensure that label names follow [Prometheus naming conventions](https://prometheus.io/docs/practices/naming/).
 
 ## Optional metrics
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ app.add_middleware(
 
 **Warning: this feature is experimental.**
 
-Most metrics have default labels including `app_name`, `method`, `path`, and `status_code`.  Additional default labels can be
+Metrics have built-in default labels including `app_name`, `method`, `path`, and `status_code`.  Additional default labels can be
 added by passing a dictionary to the `labels` arg to `PrometheusMiddleware`.  Each label's value can be either a static
 value or, optionally, a callback function.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ app.add_route("/metrics", handle_metrics)
 
 `prefix`: Sets the prefix of the exported metric names (default: `starlette`).
 
+`labels`: Optional dict containing default labels that will be added to all metrics. The values can be either a static value or a callback function that
+retrieves a value from the `Request` object. [See below](#labels) for examples.
+
 `group_paths`: setting this to `True` will populate the path label using named parameters (if any) in the router path, e.g. `/api/v1/items/{item_id}`.  This will group requests together by endpoint (regardless of the value of `item_id`). This option may come with a performance hit for larger routers. Default is `False`, which will result in separate metrics for different URLs (e.g., `/api/v1/items/42`, `/api/v1/items/43`, etc.).
 
 `filter_unhandled_paths`: setting this to `True` will cause the middleware to ignore requests with unhandled paths (in other words, 404 errors). This helps prevent filling up the metrics with 404 errors and/or intentially bad requests. Default is `False`.
@@ -93,11 +96,52 @@ app.add_middleware(
   PrometheusMiddleware,
   app_name="hello_world",
   prefix='myapp',
+  labels={
+      "server": os.getenv("HOSTNAME"),
+      "host": lambda r: r.headers.get("host")
+  }),
   group_paths=True,
   buckets=[0.1, 0.25, 0.5],
   skip_paths=['/health'],
-  always_use_int_status=False)
+  always_use_int_status=False,
 ```
+
+## Labels
+
+**Warning: this feature is experimental.**
+
+Most metrics have default labels including `app_name`, `method`, `path`, and `status_code`.  Additional default labels can be
+added by passing a dictionary to the `labels` arg to `PrometheusMiddleware`.  Each label's value can be either a static
+value or, optionally, a callback function.
+
+If a callback function is used, it will receive the Request instance as its argument.
+
+#### Examples:
+
+```python
+app.add_middleware(
+  PrometheusMiddleware,
+  labels={
+     "host": lambda r: r.headers.get("host")
+     "service": "api"
+    }
+```
+
+Alternatively, for header values, a convenience function is provided:
+```python
+from starlette_exporter import PrometheusMiddleware, from_header
+
+app.add_middleware(
+  PrometheusMiddleware,
+  labels={
+     "host": from_header("host")
+    }
+```
+
+For retrieving other types of values from the Request instance, use the lambda form.
+
+This functionality is experimental.  Exceptions may be raised if the label name, value or callback function is malformed. 
+Ensure that label names follow [Prometheus naming conventions](https://prometheus.io/docs/practices/naming/).
 
 ## Optional metrics
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ app.add_middleware(
   group_paths=True,
   buckets=[0.1, 0.25, 0.5],
   skip_paths=['/health'],
-  always_use_int_status=False,
+  always_use_int_status=False)
 ```
 
 ## Labels

--- a/README.md
+++ b/README.md
@@ -97,8 +97,7 @@ app.add_middleware(
   app_name="hello_world",
   prefix='myapp',
   labels={
-      "server": os.getenv("HOSTNAME"),
-      "host": lambda r: r.headers.get("host")
+      "server_name": os.getenv("HOSTNAME"),
   }),
   group_paths=True,
   buckets=[0.1, 0.25, 0.5],
@@ -108,11 +107,9 @@ app.add_middleware(
 
 ## Labels
 
-**Warning: this feature is experimental.**
-
-Metrics have built-in default labels including `app_name`, `method`, `path`, and `status_code`.  Additional default labels can be
+The included metrics have built-in default labels such as `app_name`, `method`, `path`, and `status_code`.  Additional default labels can be
 added by passing a dictionary to the `labels` arg to `PrometheusMiddleware`.  Each label's value can be either a static
-value or, optionally, a callback function.
+value or, optionally, a callback function. The built-in default label names are reserved and cannot be reused.
 
 If a callback function is used, it will receive the Request instance as its argument.
 
@@ -120,19 +117,22 @@ If a callback function is used, it will receive the Request instance as its argu
 app.add_middleware(
   PrometheusMiddleware,
   labels={
-     "host": lambda r: r.headers.get("host")
-     "service": "api"
+     "service": "api",
+     "env": os.getenv("ENV")
     }
 ```
 
-This functionality is experimental.  Exceptions may be raised if the label name, value or callback function is malformed. 
-Ensure that label names follow [Prometheus naming conventions](https://prometheus.io/docs/practices/naming/).
+Ensure that label names follow [Prometheus naming conventions](https://prometheus.io/docs/practices/naming/) and that label
+values are constrained (see [this writeup from Grafana on cardinality](https://grafana.com/blog/2022/02/15/what-are-cardinality-spikes-and-why-do-they-matter/)).
 
 ### Label helpers
 
-`from_header(key: string, allowed_values: Optional[Iterable])`:  a convenience function for using a header value as a label.
+**`from_header(key: string, allowed_values: Optional[Iterable])`**:  a convenience function for using a header value as a label.
+
 `allowed_values` allows you to supply a list of allowed values. If supplied, header values not in the list will result in
 an empty string being returned.  This allows you to constrain the label values, reducing the risk of excessive cardinality.
+
+Do not use headers that could contain unconstrained values (e.g. user id) or user-supplied values.
 
 ```python
 from starlette_exporter import PrometheusMiddleware, from_header
@@ -140,7 +140,7 @@ from starlette_exporter import PrometheusMiddleware, from_header
 app.add_middleware(
   PrometheusMiddleware,
   labels={
-      "host": from_header("X-User", allowed_values=("frank", "estelle"))
+      "host": from_header("X-Internal-Org", allowed_values=("accounting", "marketing", "product"))
     }
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="starlette_exporter",
-    version="0.13.0",
+    version="0.14.0",
     author="Stephen Hillier",
     author_email="stephenhillier@gmail.com",
     packages=["starlette_exporter"],

--- a/starlette_exporter/__init__.py
+++ b/starlette_exporter/__init__.py
@@ -10,6 +10,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from .middleware import PrometheusMiddleware
+from .labels import from_header
 
 
 def handle_metrics(request: Request) -> Response:

--- a/starlette_exporter/__init__.py
+++ b/starlette_exporter/__init__.py
@@ -24,11 +24,11 @@ def handle_metrics(request: Request) -> Response:
     """
     registry = REGISTRY
     if (
-        'prometheus_multiproc_dir' in os.environ
-        or 'PROMETHEUS_MULTIPROC_DIR' in os.environ
+        "prometheus_multiproc_dir" in os.environ
+        or "PROMETHEUS_MULTIPROC_DIR" in os.environ
     ):
         registry = CollectorRegistry()
         multiprocess.MultiProcessCollector(registry)
 
-    headers = {'Content-Type': CONTENT_TYPE_LATEST}
+    headers = {"Content-Type": CONTENT_TYPE_LATEST}
     return Response(generate_latest(registry), status_code=200, headers=headers)

--- a/starlette_exporter/labels.py
+++ b/starlette_exporter/labels.py
@@ -1,0 +1,39 @@
+"""utilities for working with labels"""
+from typing import Callable
+
+from starlette.requests import Request
+
+def from_header(key: str) -> Callable:
+    """returns a function that retrieves a header value from a request.
+    The returned function can be passed to the `labels` argument of PrometheusMiddleware
+    to label metrics using a header value.
+
+    example:
+
+    ```
+        PrometheusMiddleware(
+            labels={
+                "host": from_header("host")
+            }
+        )
+    ```
+
+    
+    This function is essentially the same as using:
+
+    ```
+        PrometheusMiddleware(
+            labels={
+                "host": lambda r: r.headers.get("host")
+            }
+        )
+    ```
+    If similar functionality is needed using something other than the request headers,
+    try using the lambda function form.
+    """
+
+    def inner(r: Request):
+        return r.headers.get(key, None)
+
+    return inner
+        

--- a/starlette_exporter/labels.py
+++ b/starlette_exporter/labels.py
@@ -3,7 +3,8 @@ from typing import Callable, Iterable, Optional
 
 from starlette.requests import Request
 
-def from_header(key: str, allowed_values: Optional[Iterable]=None) -> Callable:
+
+def from_header(key: str, allowed_values: Optional[Iterable] = None) -> Callable:
     """returns a function that retrieves a header value from a request.
     The returned function can be passed to the `labels` argument of PrometheusMiddleware
     to label metrics using a header value.
@@ -35,4 +36,3 @@ def from_header(key: str, allowed_values: Optional[Iterable]=None) -> Callable:
         return v
 
     return inner
-        

--- a/starlette_exporter/labels.py
+++ b/starlette_exporter/labels.py
@@ -1,39 +1,38 @@
 """utilities for working with labels"""
-from typing import Callable
+from typing import Callable, Iterable, Optional
 
 from starlette.requests import Request
 
-def from_header(key: str) -> Callable:
+def from_header(key: str, allowed_values: Optional[Iterable]=None) -> Callable:
     """returns a function that retrieves a header value from a request.
     The returned function can be passed to the `labels` argument of PrometheusMiddleware
     to label metrics using a header value.
+
+    `key`: header key
+    `allowed_values`: an iterable (e.g. list or tuple) containing an allowlist of values. Any
+    header value not in allowed_values will result in an empty string being returned.  Use
+    this to constrain the potential label values.
 
     example:
 
     ```
         PrometheusMiddleware(
             labels={
-                "host": from_header("host")
+                "host": from_header("X-User", allowed_values=("frank", "estelle"))
             }
         )
     ```
-
-    
-    This function is essentially the same as using:
-
-    ```
-        PrometheusMiddleware(
-            labels={
-                "host": lambda r: r.headers.get("host")
-            }
-        )
-    ```
-    If similar functionality is needed using something other than the request headers,
-    try using the lambda function form.
     """
 
     def inner(r: Request):
-        return r.headers.get(key, None)
+        v = r.headers.get(key, "")
+
+        # if allowed_values was supplied, return a blank string if
+        # the value of the header does match any of the values.
+        if allowed_values is not None and v not in allowed_values:
+            return ""
+
+        return v
 
     return inner
         

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -61,7 +61,7 @@ class PrometheusMiddleware:
         skip_paths: Optional[List[str]] = None,
         optional_metrics: Optional[List[str]] = None,
         always_use_int_status: bool = False,
-        labels: Optional[Mapping[str, Union[str, Callable]]] = None
+        labels: Optional[Mapping[str, Union[str, Callable]]] = None,
     ):
         self.app = app
         self.group_paths = group_paths
@@ -79,7 +79,6 @@ class PrometheusMiddleware:
             self.optional_metrics_list = optional_metrics
         self.always_use_int_status = always_use_int_status
 
-
         self.labels = OrderedDict(labels) if labels is not None else None
 
     # Starlette initialises middleware multiple times, so store metrics on the class
@@ -90,7 +89,13 @@ class PrometheusMiddleware:
             PrometheusMiddleware._metrics[metric_name] = Counter(
                 metric_name,
                 "Total HTTP requests",
-                ("method", "path", "status_code", "app_name", *self._default_label_keys()),
+                (
+                    "method",
+                    "path",
+                    "status_code",
+                    "app_name",
+                    *self._default_label_keys(),
+                ),
             )
         return PrometheusMiddleware._metrics[metric_name]
 
@@ -112,7 +117,13 @@ class PrometheusMiddleware:
                 PrometheusMiddleware._metrics[metric_name] = Counter(
                     metric_name,
                     "Total HTTP response body bytes",
-                    ("method", "path", "status_code", "app_name", *self._default_label_keys()),
+                    (
+                        "method",
+                        "path",
+                        "status_code",
+                        "app_name",
+                        *self._default_label_keys(),
+                    ),
                 )
             return PrometheusMiddleware._metrics[metric_name]
         else:
@@ -132,7 +143,13 @@ class PrometheusMiddleware:
                 PrometheusMiddleware._metrics[metric_name] = Counter(
                     metric_name,
                     "Total HTTP request body bytes",
-                    ("method", "path", "status_code", "app_name", *self._default_label_keys()),
+                    (
+                        "method",
+                        "path",
+                        "status_code",
+                        "app_name",
+                        *self._default_label_keys(),
+                    ),
                 )
             return PrometheusMiddleware._metrics[metric_name]
         else:
@@ -145,7 +162,13 @@ class PrometheusMiddleware:
             PrometheusMiddleware._metrics[metric_name] = Histogram(
                 metric_name,
                 "HTTP request duration, in seconds",
-                ("method", "path", "status_code", "app_name", *self._default_label_keys()),
+                (
+                    "method",
+                    "path",
+                    "status_code",
+                    "app_name",
+                    *self._default_label_keys(),
+                ),
                 **self.kwargs,
             )
         return PrometheusMiddleware._metrics[metric_name]
@@ -189,7 +212,6 @@ class PrometheusMiddleware:
             values.append(v)
 
         return values
-        
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] not in ["http"]:
@@ -267,7 +289,9 @@ class PrometheusMiddleware:
             await self.app(scope, receive, wrapped_send)
         finally:
             # Decrement 'requests_in_progress' gauge after response sent
-            self.requests_in_progress.labels(method, self.app_name, *default_labels).dec()
+            self.requests_in_progress.labels(
+                method, self.app_name, *default_labels
+            ).dec()
 
             if self.filter_unhandled_paths or self.group_paths:
                 grouped_path = self._get_router_path(scope)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -539,15 +539,13 @@ class TestAlwaysUseIntStatus:
             in metrics
         ), metrics
 
+
 class TestDefaultLabels:
     """tests for the default labels option (`labels` argument on the middleware constructor)"""
 
     def test_str_default_labels(self, testapp):
         """test setting default labels with string values"""
-        labels = {
-            "foo": "bar",
-            "hello": "world"
-        }
+        labels = {"foo": "bar", "hello": "world"}
         client = TestClient(testapp(labels=labels))
         client.get("/200")
         metrics = client.get("/metrics").content.decode()
@@ -563,10 +561,7 @@ class TestDefaultLabels:
         # set up a callable that retrieves a header value from the request
         f = lambda x: x.headers.get("foo")
 
-        labels = {
-            "foo": f,
-            "hello": "world"
-        }
+        labels = {"foo": f, "hello": "world"}
 
         client = TestClient(testapp(labels=labels))
         client.get("/200", headers={"foo": "bar"})
@@ -579,10 +574,7 @@ class TestDefaultLabels:
 
     def test_from_header(self, testapp):
         """test with the library-provided from_header function"""
-        labels = {
-            "foo": from_header("foo"), 
-            "hello": "world"
-        }
+        labels = {"foo": from_header("foo"), "hello": "world"}
         client = TestClient(testapp(labels=labels))
         client.get("/200", headers={"foo": "bar"})
         metrics = client.get("/metrics").content.decode()
@@ -595,8 +587,8 @@ class TestDefaultLabels:
     def test_from_header_allowed_values(self, testapp):
         """test with the library-provided from_header function"""
         labels = {
-            "foo": from_header("foo", allowed_values=("bar", "baz")), 
-            "hello": "world"
+            "foo": from_header("foo", allowed_values=("bar", "baz")),
+            "hello": "world",
         }
         client = TestClient(testapp(labels=labels))
         client.get("/200", headers={"foo": "bar"})
@@ -606,12 +598,12 @@ class TestDefaultLabels:
             """starlette_requests_total{app_name="starlette",foo="bar",hello="world",method="GET",path="/200",status_code="200"} 1.0"""
             in metrics
         ), metrics
-    
+
     def test_from_header_allowed_values_disallowed_value(self, testapp):
         """test with the library-provided from_header function"""
         labels = {
-            "foo": from_header("foo", allowed_values=("bar", "baz")), 
-            "hello": "world"
+            "foo": from_header("foo", allowed_values=("bar", "baz")),
+            "hello": "world",
         }
         client = TestClient(testapp(labels=labels))
         client.get("/200", headers={"foo": "zounds"})


### PR DESCRIPTION
Adds a `labels` argument to `PrometheusMiddleware` that accepts a dict of labels/values that will be added to all metrics.

Each label's value can be either a static value or, optionally, a callback function that takes the Request instance as its argument and returns a string.

Example:

```python
app.add_middleware(
  PrometheusMiddleware,
  labels={
     "service": "api",
     "env": os.getenv("ENV")
    }
```