### PR TITLE
add exemplar support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ retrieves a value from the `Request` object. [See below](#labels) for examples.
 
 `skip_paths`: accepts an optional list of paths that will not collect metrics. The default value is `None`, which will cause the library to collect metrics on every requested path. This option is useful to avoid collecting metrics on health check, readiness or liveness probe endpoints.
 
-`always_use_int_status`: accepts a boolean. The default value is False. If set to True the libary will attempt to convert the `status_code` value to an integer. If the conversion fails it will log a warning and use the initial value. This is useful if you use [`http.HTTStatus`](https://docs.python.org/3/library/http.html#http.HTTPStatus) in your code but want your metrics to emit only a integer status code.
+`always_use_int_status`: accepts a boolean. The default value is False. If set to True the libary will attempt to convert the `status_code` value to an integer (e.g. if you are using HTTPStatus, HTTPStatus.OK will become 200 for all metrics).
 
 `optional_metrics`: a list of pre-defined metrics that can be optionally added to the default metrics. The following optional metrics are available:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ starlette==0.23.1
 requests==2.28.2
 aiofiles==22.1.0
 pytest==6.2.4
+httpx==0.23.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-prometheus-client==0.7.1
-starlette==0.12.9
-requests==2.22.0
-aiofiles==0.7.0
+prometheus-client==0.15.0
+starlette==0.23.1
+requests==2.28.2
+aiofiles==22.1.0
 pytest==6.2.4

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="starlette_exporter",
-    version="0.14.0",
+    version="0.15.0",
     author="Stephen Hillier",
     author_email="stephenhillier@gmail.com",
     packages=["starlette_exporter"],
@@ -12,5 +12,5 @@ setup(
     description="Prometheus metrics exporter for Starlette applications.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    install_requires=["prometheus_client", "starlette"],
+    install_requires=["prometheus_client>=0.12", "starlette"],
 )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -13,7 +13,12 @@ from starlette.staticfiles import StaticFiles
 from starlette.testclient import TestClient
 
 import starlette_exporter
-from starlette_exporter import PrometheusMiddleware, handle_metrics, from_header
+from starlette_exporter import (
+    PrometheusMiddleware,
+    handle_metrics,
+    from_header,
+    handle_openmetrics,
+)
 from starlette_exporter.optional_metrics import response_body_size, request_body_size
 
 
@@ -34,14 +39,17 @@ def testapp():
             starlette_exporter.PrometheusMiddleware, **middleware_options
         )
         app.add_route("/metrics", handle_metrics)
+        app.add_route("/openmetrics", handle_openmetrics)
 
-        @app.route("/200")
-        @app.route("/200/{test_param}", methods=["GET", "POST", "OPTIONS"])
         def normal_response(request):
             return JSONResponse({"message": "Hello World"})
 
-        @app.route("/200_or_httpstatus/{test_param}", methods=["GET", "OPTIONS"])
-        def httpstatus_respnse(request):
+        app.add_route("/200", normal_response)
+        app.add_route(
+            "/200/{test_param}", normal_response, methods=["GET", "POST", "OPTIONS"]
+        )
+
+        def httpstatus_response(request):
             """
             Returns a JSON Response using status_code = HTTPStatus.OK if the param is set to OK
             otherewise it returns a JSON response with status_code = 200
@@ -51,29 +59,25 @@ def testapp():
             else:
                 return Response(status_code=200)
 
-        @app.route("/200_with_httpstatus/{test_param}", methods=["GET", "OPTIONS"])
-        def httpstatus_respnse(request):
-            """
-            Returns a JSON Response using status_code = HTTPStatus.OK if the param is set to OK
-            otherewise it returns a JSON response with status_code = 200
-            """
-            if request.path_params["test_param"] == "OK":
-                return Response(status_code=HTTPStatus.OK)
-            else:
-                return Response(status_code=200)
+        app.add_route(
+            "/200_or_httpstatus/{test_param}",
+            httpstatus_response,
+            methods=["GET", "OPTIONS"],
+        )
 
-        @app.route("/500")
-        @app.route("/500/{test_param}")
         async def error(request):
             raise HTTPException(status_code=500, detail="this is a test error")
 
-        @app.route("/unhandled")
-        @app.route("/unhandled/{test_param}")
+        app.add_route("/500", error)
+        app.add_route("/500/{test_param}", error)
+
         async def unhandled(request):
             test_dict = {"yup": 123}
             return JSONResponse({"message": test_dict["value_error"]})
 
-        @app.route("/background")
+        app.add_route("/unhandled", unhandled)
+        app.add_route("/unhandled/{test_param}", unhandled)
+
         async def background(request):
             def backgroundtask():
                 time.sleep(0.1)
@@ -81,9 +85,12 @@ def testapp():
             task = BackgroundTask(backgroundtask)
             return JSONResponse({"message": "task started"}, background=task)
 
-        @app.route("/health")
+        app.add_route("/background", background)
+
         def healthcheck(request):
             return JSONResponse({"message": "Healthcheck route"})
+
+        app.add_route("/health", healthcheck)
 
         # testing routes added using Mount
         async def test_mounted_function(request):
@@ -616,5 +623,32 @@ class TestDefaultLabels:
 
         assert (
             """starlette_requests_total{app_name="starlette",foo="",hello="world",method="GET",path="/200",status_code="200"} 1.0"""
+            in metrics
+        ), metrics
+
+
+class TestExemplars:
+    """tests for adding an exemplar to the histogram and counters"""
+
+    def test_exemplar(self, testapp):
+        """test setting default labels with string values"""
+
+        # create a callable that returns a label/value pair to
+        # be used as an exemplar.
+        def exemplar_fn():
+            return {"trace_id": "abc123"}
+
+        # create a label for this test so we have a unique output line
+        labels = {"test": "exemplar"}
+
+        client = TestClient(testapp(exemplars=exemplar_fn, labels=labels))
+        client.get("/200")
+
+        metrics = client.get(
+            "/openmetrics", headers={"Accept": "application/openmetrics-text"}
+        ).content.decode()
+
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200",test="exemplar"} 1.0 # {trace_id="abc123"}"""
             in metrics
         ), metrics

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -523,18 +523,6 @@ class TestAlwaysUseIntStatus:
             in metrics
         ), metrics
 
-    def test_200_HTTPStatusOK(self, testapp):
-        """Test that status_code metric is HTTPStatus.OK if status_code=HTTPStatus.OK in the response
-        and always_use_int_status is not set"""
-        client = TestClient(testapp())
-        client.get("/200_or_httpstatus/OK")
-        metrics = client.get("/metrics").content.decode()
-
-        assert (
-            """starlette_requests_total{app_name="starlette",method="GET",path="/200_or_httpstatus/OK",status_code="HTTPStatus.OK"} 1.0"""
-            in metrics
-        ), metrics
-
     def test_200_always_use_int_status_set(self, testapp):
         """Test that status_code metric is 200 if status_code=200 in the response and always_use_int_status is set"""
         client = TestClient(testapp(always_use_int_status=True))


### PR DESCRIPTION
Add exemplar support (see README for documentation).

Also remove automated testing for Python 3.6 (it is EOL) and add it for Python 3.11.

Note: testing this PR with Python 3.11 surfaced a minor breaking change for 3.11 HTTPStatus enums:  If you are using HTTPStatus in your FastAPI app, values like `HTTPStatus.OK` in your Prometheus metrics output will likely just be recorded as `200` after Python 3.11.  This appears to be a Python change to `Enum` and unrelated to `starlette_exporter`.  