### PR TITLE
Fix `handle_metrics` references in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ from starlette_exporter import PrometheusMiddleware, handle_metrics
 
 app = Starlette()
 app.add_middleware(PrometheusMiddleware)
-app.add_route("/metrics", openmetrics_handler)
+app.add_route("/metrics", handle_metrics)
 
 ...
 ```
@@ -62,7 +62,7 @@ from starlette_exporter import PrometheusMiddleware, handle_metrics
 
 app = FastAPI()
 app.add_middleware(PrometheusMiddleware)
-app.add_route("/metrics", openmetrics_handler)
+app.add_route("/metrics", handle_metrics)
 
 ...
 ```


### PR DESCRIPTION
The example snippets to configure the exporter in Starlette and FastAPI point to `openmetrics_handler` instead of `handle_metrics` (which is the function that is actually imported).