### PR TITLE
Fix explicitly export attribute mypy error

### DIFF
--- a/starlette_exporter/__init__.py
+++ b/starlette_exporter/__init__.py
@@ -1,3 +1,9 @@
+__all__ = [
+    'PrometheusMiddleware',
+    'from_header',
+    'handle_metrics',
+]
+
 import os
 from prometheus_client import (
     generate_latest,


### PR DESCRIPTION
Mypy in strict mode reports:
```
Mypy: Module "starlette_exporter" does not explicitly export attribute "PrometheusMiddleware"  [attr-defined]
```