### PR TITLE
Include skip_methods option to avoid collecting metrics for specific methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ retrieves a value from the `Request` object. [See below](#labels) for examples.
 
 `skip_paths`: accepts an optional list of paths that will not collect metrics. The default value is `None`, which will cause the library to collect metrics on every requested path. This option is useful to avoid collecting metrics on health check, readiness or liveness probe endpoints.
 
+`skip_methods`: accepts an optional list of methods that will not collect metrics. The default value is `None`, which will cause the library to collect request metrics with each method. This option is useful to avoid collecting metrics on requests related to the communication description for endpoints.
+
 `always_use_int_status`: accepts a boolean. The default value is False. If set to True the libary will attempt to convert the `status_code` value to an integer (e.g. if you are using HTTPStatus, HTTPStatus.OK will become 200 for all metrics).
 
 `optional_metrics`: a list of pre-defined metrics that can be optionally added to the default metrics. The following optional metrics are available:
@@ -107,6 +109,7 @@ app.add_middleware(
   group_paths=True,
   buckets=[0.1, 0.25, 0.5],
   skip_paths=['/health'],
+  skip_methods=['OPTIONS'],
   always_use_int_status=False),
   exemplars=lambda: {"trace_id": get_trace_id}  # function that returns a trace id
 ```

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="starlette_exporter",
-    version="0.15.1",
+    version="0.15.2",
     author="Stephen Hillier",
     author_email="stephenhillier@gmail.com",
     packages=["starlette_exporter"],

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -71,6 +71,7 @@ class PrometheusMiddleware:
         buckets: Optional[Sequence[Union[float, str]]] = None,
         filter_unhandled_paths: bool = False,
         skip_paths: Optional[List[str]] = None,
+        skip_methods: Optional[List[str]] = None,
         optional_metrics: Optional[List[str]] = None,
         always_use_int_status: bool = False,
         labels: Optional[Mapping[str, Union[str, Callable]]] = None,
@@ -87,6 +88,9 @@ class PrometheusMiddleware:
         self.skip_paths = []
         if skip_paths is not None:
             self.skip_paths = skip_paths
+        self.skip_methods = []
+        if skip_methods is not None:
+            self.skip_methods = skip_methods
         self.optional_metrics_list = []
         if optional_metrics is not None:
             self.optional_metrics_list = optional_metrics
@@ -237,7 +241,7 @@ class PrometheusMiddleware:
         method = request.method
         path = request.url.path
 
-        if path in self.skip_paths:
+        if path in self.skip_paths or method in self.skip_methods:
             await self.app(scope, receive, send)
             return
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -347,6 +347,13 @@ class TestMiddleware:
         metrics = client.get("/metrics").content.decode()
         assert """path="/health""" not in metrics
 
+    def test_skip_methods(self, testapp):
+        """test that requests doesn't appear in the counter"""
+        client = TestClient(testapp(skip_methods=["POST"]))
+        client.post("/200")
+        metrics = client.get("/metrics").content.decode()
+        assert """path="/200""" not in metrics
+
 
 class TestMiddlewareGroupedPaths:
     """tests for group_paths option (using named parameters to group endpoint metrics with path params together)"""


### PR DESCRIPTION
## What does this Pull Request do?

Adds an option to avoid collecting metrics on request with specific methods.
This option can be used to avoid collecting metrics on, for example, communication description requests for endpoints (but can be used in any other method).
The new option is an optional list called `skip_methods`.

Example:
```python
app.add_middleware(
  PrometheusMiddleware,
  app_name="hello_world",
  prefix='myapp',
  labels={
      "server_name": os.getenv("HOSTNAME"),
  }),
  group_paths=True,
  buckets=[0.1, 0.25, 0.5],
  skip_paths=['/health'],
  skip_methods=['OPTIONS'],
  always_use_int_status=False),
  exemplars=lambda: {"trace_id": get_trace_id}  # function that returns a trace id
```

## On the justification

We have an application using microservices architecture, at the beginning of which there is a gateway that forwards requests with a given path or method. From this point, we monitor the metrics. Prometheus is not able to process such a large generated traffic, which we already reduce by ignoring some paths, so we also want to reduce it by ignoring requests containing some methods (namely `OPTIONS`), because they are not important to us. This change may allow us to get a performance benefit. I will be very pleased with the opportunity to contribute to your project.

@stephenhillier 