### PR TITLE
bumping version of starlette to 0.25.0 to fix security issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 prometheus-client==0.15.0
-starlette==0.23.1
+starlette==0.25.0
 requests==2.28.2
 aiofiles==22.1.0
 pytest==6.2.4


### PR DESCRIPTION
Starlette reported a security issue a couple months ago https://github.com/encode/starlette/pull/2035

Bumping the required starlette version to the version that fixes the issue. Holding off on upgrading to 0.26+ as there are open issues.