### PR TITLE
Update starlette to 0.35+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.12
     - name: Lint with flake8
       run: |
         python -m pip install --upgrade pip
@@ -32,10 +32,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.12
     - name: Type checking with mypy
       run: |
         python -m pip install --upgrade pip
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     runs-on: ubuntu-latest
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 prometheus-client==0.15.0
-starlette==0.27.0
+starlette==0.35.1
 requests==2.31.0
 aiofiles==22.1.0
 pytest==6.2.4

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(
     description="Prometheus metrics exporter for Starlette applications.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    install_requires=["prometheus_client>=0.12", "starlette"],
+    install_requires=["prometheus_client>=0.12", "starlette>=0.35"],
 )

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,5 @@ setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     install_requires=["prometheus_client>=0.12", "starlette>=0.35"],
+    python_requires=">=3.8",
 )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -158,7 +158,7 @@ class TestMiddleware:
             pass
         metrics = client.get("/metrics").content.decode()
 
-        assert "404" not in metrics
+        assert "/404" not in metrics
 
     def test_unhandled(self, client):
         """test that an unhandled exception still gets logged in the requests counter"""
@@ -520,7 +520,7 @@ class TestMiddlewareGroupedPaths:
             """starlette_requests_total{app_name="starlette",method="GET",path="/unhandled/{test_param}",status_code="500"} 1.0"""
             in metrics
         )
-        assert "404" not in metrics
+        assert "/404" not in metrics
 
     def test_mounted_path_404(self, testapp):
         """test an unhandled path that will be partially matched at the mounted base path (grouped paths)"""

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -3,7 +3,6 @@ from http import HTTPStatus
 
 import pytest
 from prometheus_client import REGISTRY
-from starlette import __version__ as starlette_version
 from starlette.applications import Starlette
 from starlette.background import BackgroundTask
 from starlette.exceptions import HTTPException
@@ -218,19 +217,19 @@ class TestMiddleware:
         metrics = client.get("/metrics").content.decode()
 
         assert (
-            """starlette_requests_total{app_name="starlette",method="GET",path="/api/200",status_code="200"} 1.0"""
+            """starlette_requests_total{app_name="starlette",method="GET",path="/200",status_code="200"} 1.0"""
             in metrics
         )
         assert (
-            """starlette_requests_total{app_name="starlette",method="GET",path="/api/500",status_code="500"} 1.0"""
+            """starlette_requests_total{app_name="starlette",method="GET",path="/500",status_code="500"} 1.0"""
             in metrics
         )
         assert (
-            """starlette_requests_total{app_name="starlette",method="GET",path="/api/404",status_code="404"} 1.0"""
+            """starlette_requests_total{app_name="starlette",method="GET",path="/404",status_code="404"} 1.0"""
             in metrics
         )
         assert (
-            """starlette_requests_total{app_name="starlette",method="GET",path="/api/unhandled",status_code="500"} 1.0"""
+            """starlette_requests_total{app_name="starlette",method="GET",path="/unhandled",status_code="500"} 1.0"""
             in metrics
         )
 
@@ -508,12 +507,6 @@ class TestMiddlewareGroupedPaths:
             client.get("/unhandled/123")
 
         metrics = client.get("/metrics").content.decode()
-
-        starlette_version_tuple = tuple(map(int, starlette_version.split(".")))
-        if starlette_version_tuple < (0, 33):
-            # These asserts are valid only on Starlette 0.33+
-            # See https://github.com/encode/starlette/pull/2352"
-            return
 
         assert (
             """starlette_requests_total{app_name="starlette",method="GET",path="/200/{test_param}",status_code="200"} 1.0"""


### PR DESCRIPTION
Since starlette==0.35.0 https://github.com/encode/starlette/pull/2400 `scope["path"]` is now handled differently. This fixes different paths in tests `TestMiddleware.test_custom_root_path` and `TestMiddlewareGroupedPaths.test_custom_root_path`.

I'e updated the test, and also set minimal starlette version to 0.35. It does not support Python 3.7, so I've removed it from supported versions.