### PR TITLE
[Feature] Group unhandled paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ retrieves a value from the `Request` object. [See below](#labels) for examples.
 
 `filter_unhandled_paths`: setting this to `True` will cause the middleware to ignore requests with unhandled paths (in other words, 404 errors). This helps prevent filling up the metrics with 404 errors and/or intentially bad requests. Default is `True`.
 
+`group_unhandled_paths`: similar to `filter_unhandled_paths`, but instead of ignoring the requests, they are grouped under `__unknown__` path. To use this option, you need to disable `filter_unhandled_paths`. Default is `False`.
+
 `buckets`: accepts an optional list of numbers to use as histogram buckets. The default value is `None`, which will cause the library to fall back on the Prometheus defaults (currently `[0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0]`).
 
 `skip_paths`: accepts an optional list of paths that will not collect metrics. The default value is `None`, which will cause the library to collect metrics on every requested path. This option is useful to avoid collecting metrics on health check, readiness or liveness probe endpoints.

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -84,6 +84,7 @@ class PrometheusMiddleware:
         app_name: str = "starlette",
         prefix: str = "starlette",
         buckets: Optional[Sequence[Union[float, str]]] = None,
+        group_unhandled_paths: bool = False,
         filter_unhandled_paths: bool = True,
         skip_paths: Optional[List[str]] = None,
         skip_methods: Optional[List[str]] = None,
@@ -96,6 +97,13 @@ class PrometheusMiddleware:
         self.app_name = app_name
         self.prefix = prefix
         self.group_paths = group_paths
+
+        if group_unhandled_paths and filter_unhandled_paths:
+            raise ValueError(
+                "group_unhandled_paths and filter_unhandled_paths cannot both be True"
+            )
+
+        self.group_unhandled_paths = group_unhandled_paths
         self.filter_unhandled_paths = filter_unhandled_paths
 
         self.kwargs = {}
@@ -337,7 +345,7 @@ class PrometheusMiddleware:
             method, self.app_name, *default_labels
         ).dec()
 
-        if self.filter_unhandled_paths or self.group_paths:
+        if self.filter_unhandled_paths or self.group_paths or self.group_unhandled_paths:
             grouped_path: Optional[str] = None
 
             endpoint = scope.get("endpoint", None)
@@ -357,6 +365,11 @@ class PrometheusMiddleware:
             # will both be grouped under /api/product/{product_id}. See the README for more info.
             if self.group_paths and grouped_path is not None:
                 path = grouped_path
+
+            # group_unhandled_paths works similar to filter_unhandled_paths, but instead of
+            # removing the request from the metrics, it groups it under a single path.
+            if self.group_unhandled_paths and grouped_path is None:
+                path = "__unknown__"
 
         if status_code is None:
             if await request.is_disconnected():

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -159,6 +159,17 @@ class TestMiddleware:
         metrics = client.get("/metrics").content.decode()
 
         assert "/404" not in metrics
+    
+    def test_404_group_unhandled_paths_on(self, testapp):
+        """test that an unknown path is captured in metrics if group_unhandled_paths=True"""
+        client = TestClient(testapp(group_unhandled_paths=True, filter_unhandled_paths=False))
+        client.get("/404")
+        metrics = client.get("/metrics").content.decode()
+
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="__unknown__",status_code="404"} 1.0"""
+            in metrics
+        )
 
     def test_unhandled(self, client):
         """test that an unhandled exception still gets logged in the requests counter"""


### PR DESCRIPTION
@stephenhillier I started working on the update discussed in #82 and I am going with `__unknown__` value in the end as the `_` symbol is unlikely to conflict with some actual api endpoint.

As I was finishing up the changes, it seemed quite impractical to support both `filter_unhandled_paths` and `group_unhandled_paths` options as only one of these is applicable. It leads to weird situations like, if you want to enable `group_unhandled_paths` you also need to explicitly disable `filter_unhandled_paths` as it is enabled by default. Maybe 2 different flags are not the right way to go? Maybe an option like `unhandled_paths_strategy` accepting string values `ignore` (replacement for `filter_unhandled_paths`), `group` (replacement for `group_unhandled_paths`), or `unique` (replacement for setting both `filter_unhandled_paths` and `group_unhandled_paths ` to `False`, but not sure about the name `unique`) to decide how to handle these situations. I think this would be a better way to go, but if we remove the `filter_unhandled_paths`, it will be a breaking change.

If we go with `unhandled_paths_strategy` option, the default value could be actually based on `group_paths` option. If enabled, the default value would be `group`, if disabled, default value could be `unique`.

If we go with `group_unhandled_paths` option, what should happen if both `filter_unhandled_paths` and `group_unhandled_paths` are set to `True`? I threw an error, but I am not sure if thats the right way to go.

I pushed the original solution as a draft and we can discuss which direction we should go.

Going with a new flag would be least disruptive to users as it does not introduce any breaking changes, but seems quite unintuitive when setting up the configuration (disabling one flag to be able to enable another one).