### PR TITLE
[Feature] Add `group_unhandled_paths` Option to Enhance `filter_unhandled_paths` Functionality  #91

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ retrieves a value from the `Request` object. [See below](#labels) for examples.
 
 `filter_unhandled_paths`: setting this to `True` will cause the middleware to ignore requests with unhandled paths (in other words, 404 errors). This helps prevent filling up the metrics with 404 errors and/or intentially bad requests. Default is `True`.
 
+`group_unhandled_paths`: Similar to `filter_unhandled_paths`, but instead of ignoring the requests, they are grouped under the `__unknown__` path. This option overrides `filter_unhandled_paths` by setting it to `False`. The default value is `False`.
+
 `buckets`: accepts an optional list of numbers to use as histogram buckets. The default value is `None`, which will cause the library to fall back on the Prometheus defaults (currently `[0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0]`).
 
 `skip_paths`: accepts an optional list of paths, or regular expressions for paths, that will not collect metrics. The default value is `None`, which will cause the library to collect metrics on every requested path. This option is useful to avoid collecting metrics on health check, readiness or liveness probe endpoints.

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -162,6 +162,19 @@ class TestMiddleware:
 
         assert "/404" not in metrics
 
+    def test_404_group_unhandled_paths_on(self, testapp):
+        """test that an unknown path is captured in metrics if group_unhandled_paths=True"""
+
+        client = TestClient(testapp(group_unhandled_paths=True, filter_unhandled_paths=False))
+        client.get("/404")
+
+        metrics = client.get("/metrics").content.decode()
+
+        assert (
+            """starlette_requests_total{app_name="starlette",method="GET",path="__unknown__",status_code="404"} 1.0"""
+            in metrics
+        )
+
     def test_unhandled(self, client):
         """test that an unhandled exception still gets logged in the requests counter"""
 


### PR DESCRIPTION
**PR Title:** Add `group_unhandled_paths` Option to Enhance `filter_unhandled_paths` Functionality

Hello @stephenhillier and @Filipoliko,

Following the discussion in the previous PR and the suggestions made, I have created an alternative PR (based on @Filipoliko solution) for handling unhandled paths.

**Overview of the Changes:**
- Introduced the `group_unhandled_paths` option.
- `group_unhandled_paths`: Similar to `filter_unhandled_paths`, but instead of ignoring the requests, they are grouped under the `__unknown__` path. This option overrides `filter_unhandled_paths` by setting it to `False`. The default value is `False`.

**Reasoning:**
- This approach simplifies configuration by linking the two options, reducing potential user confusion.
- Ensures clear intent when configuring the handling of unhandled paths.
- Aligns with the feedback suggesting that `group_unhandled_paths` provides clear intend even if  `filter_unhandled_paths` is enabled and simply it overrides it.

I believe this solution addresses the concerns raised about having mutually exclusive options and makes the configuration more intuitive.

Please review this alternative approach and let me know your thoughts.
