### PR TITLE
ensure response header labels are populated during exceptions

### DIFF
--- a/starlette_exporter/labels.py
+++ b/starlette_exporter/labels.py
@@ -2,7 +2,6 @@
 from typing import Any, Callable, Iterable, Optional, Dict
 
 from starlette.requests import Request
-from starlette.types import Message
 
 
 class ResponseHeaderLabel:
@@ -13,7 +12,7 @@ class ResponseHeaderLabel:
     def __init__(
         self, key: str, allowed_values: Optional[Iterable] = None, default: str = ""
     ) -> None:
-        self.key = key
+        self.key = key.lower()
         self.default = default
         self.allowed_values = allowed_values
 

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -300,7 +300,7 @@ class PrometheusMiddleware:
 
         # create a dict of headers to make it easy to find keys
         headers = {
-            k.decode("utf-8"): v.decode("utf-8")
+            k.decode("utf-8").lower(): v.decode("utf-8")
             for (k, v) in message.get("headers", ())
         }
 
@@ -405,6 +405,10 @@ class PrometheusMiddleware:
             await self.app(scope, receive, wrapped_send)
         except Exception as e:
             status_code = 500
+
+            # during an unhandled exception, populate response labels with empty strings.
+            response_labels = self._response_label_values({})
+
             exception = e
         finally:
             # Decrement 'requests_in_progress' gauge after response sent


### PR DESCRIPTION
Labels set with the `from_response_header` helper function were not being set during unhandled exceptions, leading to a Prometheus client exception.

Also, the `from_response_header` function now uses a case-insensitive lookup of header keys.